### PR TITLE
 Fix Bukkit.createInventory() with type LECTERN

### DIFF
--- a/patches/api/0002-ItemStack-isSimiliar-API-to-skip-durability-and-name.patch
+++ b/patches/api/0002-ItemStack-isSimiliar-API-to-skip-durability-and-name.patch
@@ -1,4 +1,4 @@
-From a8e16cdb062b7206d8d9e4c5d72890f72b25dcb6 Mon Sep 17 00:00:00 2001
+From 62fc44d4b595dcd10a843da2e291b0da13f10578 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 15 Jun 2013 23:19:03 -0400
 Subject: [PATCH] ItemStack isSimiliar API to skip durability and name checks
@@ -10,11 +10,11 @@ For example, lore can be used to identify a custom item, but then if a player re
 
 This new boolean allows you to verify if the item is the same ignoring the name field by temporarily nulling it during the check.
 ---
- src/main/java/org/bukkit/inventory/ItemStack.java | 66 ++++++++++++++++++++++-
+ .../java/org/bukkit/inventory/ItemStack.java  | 66 ++++++++++++++++++-
  1 file changed, 65 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 495161f..43f8108 100644
+index 495161f6..43f81082 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -263,16 +263,80 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
@@ -100,5 +100,5 @@ index 495161f..43f8108 100644
  
      @NotNull
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0004-Add-API-for-vehicle-exit-event-reason.patch
+++ b/patches/api/0004-Add-API-for-vehicle-exit-event-reason.patch
@@ -1,14 +1,14 @@
-From 8b16e501ce61b1d90008e43aec7d61d0e5ecc27f Mon Sep 17 00:00:00 2001
+From 714f7d35f6244a6da62a5d463c676cddb893da2d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 7 Aug 2013 19:39:41 -0400
 Subject: [PATCH] Add API for vehicle exit event reason
 
 ---
- src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java | 10 ++++++++++
+ .../org/bukkit/event/vehicle/VehicleExitEvent.java     | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
-index a976c32..a583a04 100644
+index a976c32d..a583a043 100644
 --- a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
 +++ b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
 @@ -10,6 +10,16 @@ import org.jetbrains.annotations.NotNull;
@@ -29,5 +29,5 @@ index a976c32..a583a04 100644
      private boolean cancelled;
      private final LivingEntity exited;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0006-Add-Player.spigot-.getFishingHook-API.patch
+++ b/patches/api/0006-Add-Player.spigot-.getFishingHook-API.patch
@@ -1,4 +1,4 @@
-From 2724b8918eb3964a9fb07915c6b9a49c055c6960 Mon Sep 17 00:00:00 2001
+From 83e19724db2250103554162bf4aa9efdc1637309 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 14 Aug 2014 18:21:11 -0400
 Subject: [PATCH] Add Player.spigot().getFishingHook() API
@@ -8,13 +8,14 @@ Subject: [PATCH] Add Player.spigot().getFishingHook() API
  1 file changed, 8 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8d8d895..67aa711 100644
+index 8d8d8957..67aa7111 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1984,6 +1984,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1983,6 +1983,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     public class Spigot extends Entity.Spigot
      {
  
-         /**
++        /**
 +         * Gets the current Fishing Hook a player has out.
 +         * @return current fishing hook or null if the player is not fishing
 +         */
@@ -22,10 +23,9 @@ index 8d8d895..67aa711 100644
 +            throw new UnsupportedOperationException( "Not supported yet." );
 +        }
 +
-+        /**
+         /**
           * Gets the connection address of this player, regardless of whether it
           * has been spoofed or not.
-          *
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0007-add-Setter-for-player-name-in-AsyncPlayerPrelogin.patch
+++ b/patches/api/0007-add-Setter-for-player-name-in-AsyncPlayerPrelogin.patch
@@ -1,15 +1,15 @@
-From 4bdf4036e899236918bd932bb40127731e62b4ed Mon Sep 17 00:00:00 2001
+From 46c5014403a66a535ce6770813f8b1a8e6bd1568 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 28 Jan 2015 00:41:03 -0500
 Subject: [PATCH] add Setter for player name in AsyncPlayerPrelogin
 
 This is so we can change the players name early in login process
 ---
- src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java | 3 ++-
+ .../java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index 76c4a1a..e482fa0 100644
+index 76c4a1a6..e482fa06 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -18,7 +18,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
@@ -30,5 +30,5 @@ index 76c4a1a..e482fa0 100644
      /**
       * Gets the player IP address.
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0008-Fix-PlayerInteractEvent-for-Armor-Stands.patch
+++ b/patches/api/0008-Fix-PlayerInteractEvent-for-Armor-Stands.patch
@@ -1,14 +1,14 @@
-From d886baf73976ca711ebdb7ae2a89a3180949db39 Mon Sep 17 00:00:00 2001
+From 406c3c514613ea65dff992b9e2bec8f3d88d1c62 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 5 May 2015 00:34:04 -0400
 Subject: [PATCH] Fix PlayerInteractEvent for Armor Stands
 
 ---
- src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java | 2 ++
+ .../org/bukkit/event/player/PlayerInteractAtEntityEvent.java    | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java
-index 3f24d30..0d23ec9 100644
+index 3f24d302..0d23ec94 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java
 @@ -35,6 +35,7 @@ public class PlayerInteractAtEntityEvent extends PlayerInteractEntityEvent {
@@ -26,5 +26,5 @@ index 3f24d30..0d23ec9 100644
 +    */ // EMC end
  }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0012-Make-vehicle-events-entity-events-and-for-all-entiti.patch
+++ b/patches/api/0012-Make-vehicle-events-entity-events-and-for-all-entiti.patch
@@ -1,16 +1,16 @@
-From cb40d3b42af3535c4852343a2ed739f24fb4d2c0 Mon Sep 17 00:00:00 2001
+From b9b7b0c092a6db9a76b542ea6573a333c8b9d560 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 17 Nov 2015 01:02:10 -0500
 Subject: [PATCH] Make vehicle events entity events and for all entities
 
 ---
- src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java |  2 +-
- src/main/java/org/bukkit/event/vehicle/VehicleEvent.java      | 11 +++++++----
- src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java  |  3 ++-
+ .../org/bukkit/event/vehicle/VehicleEnterEvent.java   |  2 +-
+ .../java/org/bukkit/event/vehicle/VehicleEvent.java   | 11 +++++++----
+ .../org/bukkit/event/vehicle/VehicleExitEvent.java    |  3 ++-
  3 files changed, 10 insertions(+), 6 deletions(-)
 
 diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java
-index 64f21f6..6dc0430 100644
+index 64f21f68..6dc04308 100644
 --- a/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java
 +++ b/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java
 @@ -14,7 +14,7 @@ public class VehicleEnterEvent extends VehicleEvent implements Cancellable {
@@ -23,7 +23,7 @@ index 64f21f6..6dc0430 100644
          this.entered = entered;
      }
 diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
-index 63df270..e96b34b 100644
+index 63df2705..e96b34bd 100644
 --- a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
 +++ b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
 @@ -1,16 +1,19 @@
@@ -59,7 +59,7 @@ index 63df270..e96b34b 100644
      }
  }
 diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
-index a583a04..1886c44 100644
+index a583a043..1886c443 100644
 --- a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
 +++ b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
 @@ -1,5 +1,6 @@
@@ -79,5 +79,5 @@ index a583a04..1886c44 100644
          this.exited = exited;
          // Paper start
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0014-Add-UnknownCommandEvent.patch
+++ b/patches/api/0014-Add-UnknownCommandEvent.patch
@@ -1,17 +1,17 @@
-From 41cfac9d7fe59ba6aaeaeb75b2e2680c2a68d1d2 Mon Sep 17 00:00:00 2001
+From 812ed5b00776d7f56fc1553a2a28f5c47333f42b Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 3 Jan 2016 22:02:53 -0500
 Subject: [PATCH] Add UnknownCommandEvent
 
 ---
- .../customevents/UnknownCommandEvent.java          | 59 ++++++++++++++++++++++
- .../java/org/bukkit/command/SimpleCommandMap.java  |  2 +-
+ .../customevents/UnknownCommandEvent.java     | 59 +++++++++++++++++++
+ .../org/bukkit/command/SimpleCommandMap.java  |  2 +-
  2 files changed, 60 insertions(+), 1 deletion(-)
  create mode 100644 src/main/java/com/empireminecraft/customevents/UnknownCommandEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/UnknownCommandEvent.java b/src/main/java/com/empireminecraft/customevents/UnknownCommandEvent.java
 new file mode 100644
-index 0000000..071ca87
+index 00000000..071ca87d
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/UnknownCommandEvent.java
 @@ -0,0 +1,59 @@
@@ -75,7 +75,7 @@ index 0000000..071ca87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index a8e3396..e917b0d 100644
+index a8e33960..e917b0df 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
 @@ -144,7 +144,7 @@ public class SimpleCommandMap implements CommandMap {
@@ -88,5 +88,5 @@ index a8e3396..e917b0d 100644
  
          // Paper start - Plugins do weird things to workaround normal registration
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0016-MonsterEggSpawn-Events.patch
+++ b/patches/api/0016-MonsterEggSpawn-Events.patch
@@ -1,16 +1,16 @@
-From 8b432ee050f601ca42d60d9905b58a40f182aa07 Mon Sep 17 00:00:00 2001
+From 48106f3e490056d10d5fbae9d40705d9602b8cba Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 21 Nov 2016 17:02:11 -0500
 Subject: [PATCH] MonsterEggSpawn Events
 
 ---
- .../customevents/MonsterEggSpawnEvent.java         | 70 ++++++++++++++++++++++
+ .../customevents/MonsterEggSpawnEvent.java    | 70 +++++++++++++++++++
  1 file changed, 70 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/MonsterEggSpawnEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/MonsterEggSpawnEvent.java b/src/main/java/com/empireminecraft/customevents/MonsterEggSpawnEvent.java
 new file mode 100644
-index 0000000..cb54d6d
+index 00000000..cb54d6d5
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/MonsterEggSpawnEvent.java
 @@ -0,0 +1,70 @@
@@ -85,5 +85,5 @@ index 0000000..cb54d6d
 +
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0017-EmpireAPI.patch
+++ b/patches/api/0017-EmpireAPI.patch
@@ -1,12 +1,12 @@
-From 830e2192bb59258122aa7c76f4659f629e45829b Mon Sep 17 00:00:00 2001
+From 0da248c30036d6fb95cf6a75c7ff2df033e34ced Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 3 Dec 2016 22:03:07 -0500
 Subject: [PATCH] EmpireAPI
 
 ---
- src/main/java/com/empireminecraft/api/API.java     | 31 ++++++++++++++++++++++
- .../java/com/empireminecraft/api/EAPI_Entity.java  | 27 +++++++++++++++++++
- .../java/com/empireminecraft/api/EAPI_Misc.java    | 27 +++++++++++++++++++
+ .../java/com/empireminecraft/api/API.java     | 31 +++++++++++++++++++
+ .../com/empireminecraft/api/EAPI_Entity.java  | 27 ++++++++++++++++
+ .../com/empireminecraft/api/EAPI_Misc.java    | 27 ++++++++++++++++
  3 files changed, 85 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/api/API.java
  create mode 100644 src/main/java/com/empireminecraft/api/EAPI_Entity.java
@@ -14,7 +14,7 @@ Subject: [PATCH] EmpireAPI
 
 diff --git a/src/main/java/com/empireminecraft/api/API.java b/src/main/java/com/empireminecraft/api/API.java
 new file mode 100644
-index 0000000..01b7bda
+index 00000000..01b7bda8
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/API.java
 @@ -0,0 +1,31 @@
@@ -51,7 +51,7 @@ index 0000000..01b7bda
 +}
 diff --git a/src/main/java/com/empireminecraft/api/EAPI_Entity.java b/src/main/java/com/empireminecraft/api/EAPI_Entity.java
 new file mode 100644
-index 0000000..9bac212
+index 00000000..9bac2121
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/EAPI_Entity.java
 @@ -0,0 +1,27 @@
@@ -84,7 +84,7 @@ index 0000000..9bac212
 +}
 diff --git a/src/main/java/com/empireminecraft/api/EAPI_Misc.java b/src/main/java/com/empireminecraft/api/EAPI_Misc.java
 new file mode 100644
-index 0000000..64e5591
+index 00000000..64e55912
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/EAPI_Misc.java
 @@ -0,0 +1,27 @@
@@ -116,5 +116,5 @@ index 0000000..64e5591
 +public interface EAPI_Misc {
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0018-Debug-API-s.patch
+++ b/patches/api/0018-Debug-API-s.patch
@@ -1,14 +1,14 @@
-From 218a0965e00a6a00b50ab3da1c96793e8cf5761a Mon Sep 17 00:00:00 2001
+From a2899a0f7785f6118056b50edbce93371f6572b7 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 3 Dec 2016 22:27:48 -0500
 Subject: [PATCH] Debug API's
 
 ---
- src/main/java/com/empireminecraft/api/API.java | 21 +++++++++++++++++++++
+ .../java/com/empireminecraft/api/API.java     | 21 +++++++++++++++++++
  1 file changed, 21 insertions(+)
 
 diff --git a/src/main/java/com/empireminecraft/api/API.java b/src/main/java/com/empireminecraft/api/API.java
-index 01b7bda..237e557 100644
+index 01b7bda8..237e5575 100644
 --- a/src/main/java/com/empireminecraft/api/API.java
 +++ b/src/main/java/com/empireminecraft/api/API.java
 @@ -23,9 +23,30 @@
@@ -43,5 +43,5 @@ index 01b7bda..237e557 100644
 +    }
  }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0020-AchievementBroadcastEvent.patch
+++ b/patches/api/0020-AchievementBroadcastEvent.patch
@@ -1,16 +1,16 @@
-From a02fcdea20718a5647e4f4a5effcd36a84b511e3 Mon Sep 17 00:00:00 2001
+From 6d67929d39e377ac67738af515ec2bbe8ae02551 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:01:08 -0500
 Subject: [PATCH] AchievementBroadcastEvent
 
 ---
- .../customevents/AchievementBroadcastEvent.java    | 60 ++++++++++++++++++++++
+ .../AchievementBroadcastEvent.java            | 60 +++++++++++++++++++
  1 file changed, 60 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/AchievementBroadcastEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/AchievementBroadcastEvent.java b/src/main/java/com/empireminecraft/customevents/AchievementBroadcastEvent.java
 new file mode 100644
-index 0000000..326fa58
+index 00000000..326fa580
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/AchievementBroadcastEvent.java
 @@ -0,0 +1,60 @@
@@ -75,5 +75,5 @@ index 0000000..326fa58
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0021-AnvilEvent.patch
+++ b/patches/api/0021-AnvilEvent.patch
@@ -1,16 +1,16 @@
-From eb90d734d1a1f23e14008ebd8ca17018894a55a9 Mon Sep 17 00:00:00 2001
+From f29393fec66a2aedd651d1c537dceb3ccc0fed6f Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:02:45 -0500
 Subject: [PATCH] AnvilEvent
 
 ---
- .../empireminecraft/customevents/AnvilEvent.java   | 91 ++++++++++++++++++++++
+ .../customevents/AnvilEvent.java              | 91 +++++++++++++++++++
  1 file changed, 91 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/AnvilEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/AnvilEvent.java b/src/main/java/com/empireminecraft/customevents/AnvilEvent.java
 new file mode 100644
-index 0000000..efa108c
+index 00000000..efa108cd
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/AnvilEvent.java
 @@ -0,0 +1,91 @@
@@ -106,5 +106,5 @@ index 0000000..efa108c
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0022-ArrowHitBlockEvent.patch
+++ b/patches/api/0022-ArrowHitBlockEvent.patch
@@ -1,16 +1,16 @@
-From c11b2c403381deb075a605671c518e5415a5830e Mon Sep 17 00:00:00 2001
+From 607ba207810e2a2bd95f69bc3ed479ba2b396e47 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:03:19 -0500
 Subject: [PATCH] ArrowHitBlockEvent
 
 ---
- .../paper/event/entity/ArrowHitBlockEvent.java     | 92 ++++++++++++++++++++++
+ .../event/entity/ArrowHitBlockEvent.java      | 92 +++++++++++++++++++
  1 file changed, 92 insertions(+)
  create mode 100644 src/main/java/com/destroystokyo/paper/event/entity/ArrowHitBlockEvent.java
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ArrowHitBlockEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ArrowHitBlockEvent.java
 new file mode 100644
-index 0000000..34a2719
+index 00000000..34a27196
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/ArrowHitBlockEvent.java
 @@ -0,0 +1,92 @@
@@ -107,5 +107,5 @@ index 0000000..34a2719
 +
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0023-BatMoveEvent.patch
+++ b/patches/api/0023-BatMoveEvent.patch
@@ -1,16 +1,16 @@
-From 745daa58f46c717d5ca69823a26c879dbc64d03b Mon Sep 17 00:00:00 2001
+From 92fe1fdc1c3894a505d71907c2c5ade4d28b70cb Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:09:56 -0500
 Subject: [PATCH] BatMoveEvent
 
 ---
- .../empireminecraft/customevents/BatMoveEvent.java | 75 ++++++++++++++++++++++
+ .../customevents/BatMoveEvent.java            | 75 +++++++++++++++++++
  1 file changed, 75 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/BatMoveEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/BatMoveEvent.java b/src/main/java/com/empireminecraft/customevents/BatMoveEvent.java
 new file mode 100644
-index 0000000..9f18983
+index 00000000..9f189838
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/BatMoveEvent.java
 @@ -0,0 +1,75 @@
@@ -90,5 +90,5 @@ index 0000000..9f18983
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0024-BlockBreakNaturallyEvent.patch
+++ b/patches/api/0024-BlockBreakNaturallyEvent.patch
@@ -1,16 +1,16 @@
-From 3c771b230d5b1236652a1d00e91a86ae938e0418 Mon Sep 17 00:00:00 2001
+From e66505c4a28b1b7177c33cc576079a3851ccc165 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:14:52 -0500
 Subject: [PATCH] BlockBreakNaturallyEvent
 
 ---
- .../customevents/BlockBreakNaturallyEvent.java     | 36 ++++++++++++++++++++++
+ .../BlockBreakNaturallyEvent.java             | 36 +++++++++++++++++++
  1 file changed, 36 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/BlockBreakNaturallyEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/BlockBreakNaturallyEvent.java b/src/main/java/com/empireminecraft/customevents/BlockBreakNaturallyEvent.java
 new file mode 100644
-index 0000000..1fbf5b5
+index 00000000..1fbf5b59
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/BlockBreakNaturallyEvent.java
 @@ -0,0 +1,36 @@
@@ -51,5 +51,5 @@ index 0000000..1fbf5b5
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0025-EggHatchEvent.patch
+++ b/patches/api/0025-EggHatchEvent.patch
@@ -1,16 +1,16 @@
-From 5ba862bed065b43177a925ad96fe2642f6ec1a4a Mon Sep 17 00:00:00 2001
+From ddbc8af9844b2b98935ec7e2ca3955e5742da629 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:15:46 -0500
 Subject: [PATCH] EggHatchEvent
 
 ---
- .../customevents/EggHatchEvent.java                | 38 ++++++++++++++++++++++
+ .../customevents/EggHatchEvent.java           | 38 +++++++++++++++++++
  1 file changed, 38 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/EggHatchEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/EggHatchEvent.java b/src/main/java/com/empireminecraft/customevents/EggHatchEvent.java
 new file mode 100644
-index 0000000..84323b1
+index 00000000..84323b1d
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/EggHatchEvent.java
 @@ -0,0 +1,38 @@
@@ -53,5 +53,5 @@ index 0000000..84323b1
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0026-EntityKnockbackEvent.patch
+++ b/patches/api/0026-EntityKnockbackEvent.patch
@@ -1,16 +1,16 @@
-From 09c62c013eca9cb2790758fd9e3398f6259aa785 Mon Sep 17 00:00:00 2001
+From a55856155896fb198e8c039b6831c86091bd90a2 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:19:01 -0500
 Subject: [PATCH] EntityKnockbackEvent
 
 ---
- .../customevents/EntityKnockbackEvent.java         | 43 ++++++++++++++++++++++
+ .../customevents/EntityKnockbackEvent.java    | 43 +++++++++++++++++++
  1 file changed, 43 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/EntityKnockbackEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/EntityKnockbackEvent.java b/src/main/java/com/empireminecraft/customevents/EntityKnockbackEvent.java
 new file mode 100644
-index 0000000..5e10e24
+index 00000000..5e10e241
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/EntityKnockbackEvent.java
 @@ -0,0 +1,43 @@
@@ -58,5 +58,5 @@ index 0000000..5e10e24
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0027-MovedTooQuicklyEvent.patch
+++ b/patches/api/0027-MovedTooQuicklyEvent.patch
@@ -1,16 +1,16 @@
-From f362a0ed1c6793650b37cd8a2c06f00ae24963a5 Mon Sep 17 00:00:00 2001
+From 80a2bf3697226c74a3a037fed42980acaa28a8fe Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:19:22 -0500
 Subject: [PATCH] MovedTooQuicklyEvent
 
 ---
- .../customevents/MovedTooQuicklyEvent.java         | 49 ++++++++++++++++++++++
+ .../customevents/MovedTooQuicklyEvent.java    | 49 +++++++++++++++++++
  1 file changed, 49 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/MovedTooQuicklyEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/MovedTooQuicklyEvent.java b/src/main/java/com/empireminecraft/customevents/MovedTooQuicklyEvent.java
 new file mode 100644
-index 0000000..9c69b6d
+index 00000000..9c69b6da
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/MovedTooQuicklyEvent.java
 @@ -0,0 +1,49 @@
@@ -64,5 +64,5 @@ index 0000000..9c69b6d
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0028-ServerReloadEvent.patch
+++ b/patches/api/0028-ServerReloadEvent.patch
@@ -1,16 +1,16 @@
-From b75ae099d8a239475776d5efba714e6999d19eb5 Mon Sep 17 00:00:00 2001
+From 26135771db79895fcb478f9ee960f1b5a4bfac85 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:19:32 -0500
 Subject: [PATCH] ServerReloadEvent
 
 ---
- .../customevents/ServerReloadEvent.java              | 20 ++++++++++++++++++++
+ .../customevents/ServerReloadEvent.java       | 20 +++++++++++++++++++
  1 file changed, 20 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/ServerReloadEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/ServerReloadEvent.java b/src/main/java/com/empireminecraft/customevents/ServerReloadEvent.java
 new file mode 100644
-index 0000000..2a5b39d
+index 00000000..2a5b39d8
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/ServerReloadEvent.java
 @@ -0,0 +1,20 @@
@@ -35,5 +35,5 @@ index 0000000..2a5b39d
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0029-ServerShutdownEvent.patch
+++ b/patches/api/0029-ServerShutdownEvent.patch
@@ -1,16 +1,16 @@
-From c1791c74b1264ffec6919e310e88d0e49552c570 Mon Sep 17 00:00:00 2001
+From 426b609dd9f04a0a156bec3e827f178b5cac6c25 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 01:19:40 -0500
 Subject: [PATCH] ServerShutdownEvent
 
 ---
- .../customevents/ServerShutdownEvent.java          | 29 ++++++++++++++++++++++
+ .../customevents/ServerShutdownEvent.java     | 29 +++++++++++++++++++
  1 file changed, 29 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/ServerShutdownEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/ServerShutdownEvent.java b/src/main/java/com/empireminecraft/customevents/ServerShutdownEvent.java
 new file mode 100644
-index 0000000..43f761a
+index 00000000..43f761a1
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/ServerShutdownEvent.java
 @@ -0,0 +1,29 @@
@@ -44,5 +44,5 @@ index 0000000..43f761a
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0030-EntityEffectAddedEvent.patch
+++ b/patches/api/0030-EntityEffectAddedEvent.patch
@@ -1,16 +1,16 @@
-From ac633f9dca150c17173ad141fc92c7101eb2ccbc Mon Sep 17 00:00:00 2001
+From b235047844332b75a3bfdd390114c917b9fe291d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 14:59:41 -0500
 Subject: [PATCH] EntityEffectAddedEvent
 
 ---
- .../customevents/EntityEffectAddedEvent.java       | 49 ++++++++++++++++++++++
+ .../customevents/EntityEffectAddedEvent.java  | 49 +++++++++++++++++++
  1 file changed, 49 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/EntityEffectAddedEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/EntityEffectAddedEvent.java b/src/main/java/com/empireminecraft/customevents/EntityEffectAddedEvent.java
 new file mode 100644
-index 0000000..4695943
+index 00000000..4695943b
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/EntityEffectAddedEvent.java
 @@ -0,0 +1,49 @@
@@ -64,5 +64,5 @@ index 0000000..4695943
 +
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0031-FlowerPot-Events.patch
+++ b/patches/api/0031-FlowerPot-Events.patch
@@ -1,18 +1,18 @@
-From 1335df4455699e4d935be3d30d8308331821c603 Mon Sep 17 00:00:00 2001
+From 2bfe891212aa5ffa7c52bdf91351635af1ce2bef Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 15:02:53 -0500
 Subject: [PATCH] FlowerPot Events
 
 ---
- .../customevents/FlowerPotPlantEvent.java          | 34 +++++++++++
- .../customevents/FlowerPotRemoveEvent.java         | 67 ++++++++++++++++++++++
+ .../customevents/FlowerPotPlantEvent.java     | 34 ++++++++++
+ .../customevents/FlowerPotRemoveEvent.java    | 67 +++++++++++++++++++
  2 files changed, 101 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/FlowerPotPlantEvent.java
  create mode 100644 src/main/java/com/empireminecraft/customevents/FlowerPotRemoveEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/FlowerPotPlantEvent.java b/src/main/java/com/empireminecraft/customevents/FlowerPotPlantEvent.java
 new file mode 100644
-index 0000000..67d0ea7
+index 00000000..67d0ea78
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/FlowerPotPlantEvent.java
 @@ -0,0 +1,34 @@
@@ -52,7 +52,7 @@ index 0000000..67d0ea7
 +}
 diff --git a/src/main/java/com/empireminecraft/customevents/FlowerPotRemoveEvent.java b/src/main/java/com/empireminecraft/customevents/FlowerPotRemoveEvent.java
 new file mode 100644
-index 0000000..067d967
+index 00000000..067d9670
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/FlowerPotRemoveEvent.java
 @@ -0,0 +1,67 @@
@@ -124,5 +124,5 @@ index 0000000..067d967
 +
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0032-LivingEntityArmorProtectEvent.patch
+++ b/patches/api/0032-LivingEntityArmorProtectEvent.patch
@@ -1,16 +1,16 @@
-From c91794e34ad2c5b53d5b572919c180fceae0eaf1 Mon Sep 17 00:00:00 2001
+From 41c5b2de5a29fe837ea1f0f46097ea165c115a77 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 15:09:48 -0500
 Subject: [PATCH] LivingEntityArmorProtectEvent
 
 ---
- .../LivingEntityArmorProtectEvent.java             | 38 ++++++++++++++++++++++
+ .../LivingEntityArmorProtectEvent.java        | 38 +++++++++++++++++++
  1 file changed, 38 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/LivingEntityArmorProtectEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/LivingEntityArmorProtectEvent.java b/src/main/java/com/empireminecraft/customevents/LivingEntityArmorProtectEvent.java
 new file mode 100644
-index 0000000..07e0957
+index 00000000..07e09573
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/LivingEntityArmorProtectEvent.java
 @@ -0,0 +1,38 @@
@@ -53,5 +53,5 @@ index 0000000..07e0957
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0033-SpawnerInitiateEvent.patch
+++ b/patches/api/0033-SpawnerInitiateEvent.patch
@@ -1,16 +1,16 @@
-From e8c2d018be9d4903b49d49affd29084505a01b7a Mon Sep 17 00:00:00 2001
+From 497179364a54cf39f77d0e79a98a5c19f16ddc28 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 15:22:03 -0500
 Subject: [PATCH] SpawnerInitiateEvent
 
 ---
- .../customevents/SpawnerInitiateEvent.java         | 88 ++++++++++++++++++++++
+ .../customevents/SpawnerInitiateEvent.java    | 88 +++++++++++++++++++
  1 file changed, 88 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/SpawnerInitiateEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/SpawnerInitiateEvent.java b/src/main/java/com/empireminecraft/customevents/SpawnerInitiateEvent.java
 new file mode 100644
-index 0000000..6c7d582
+index 00000000..6c7d5821
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/SpawnerInitiateEvent.java
 @@ -0,0 +1,88 @@
@@ -103,5 +103,5 @@ index 0000000..6c7d582
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0034-ZombieReinforcementEvent.patch
+++ b/patches/api/0034-ZombieReinforcementEvent.patch
@@ -1,16 +1,16 @@
-From 7c3f064b6677ca43c3579d29b519c170ad6f35d1 Mon Sep 17 00:00:00 2001
+From e1d7c5dde21a26bc60046a3bbc7e8429683c185e Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 15:27:06 -0500
 Subject: [PATCH] ZombieReinforcementEvent
 
 ---
- .../customevents/ZombieReinforcementEvent.java     | 52 ++++++++++++++++++++++
+ .../ZombieReinforcementEvent.java             | 52 +++++++++++++++++++
  1 file changed, 52 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/ZombieReinforcementEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/ZombieReinforcementEvent.java b/src/main/java/com/empireminecraft/customevents/ZombieReinforcementEvent.java
 new file mode 100644
-index 0000000..5e0a9bb
+index 00000000..5e0a9bb4
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/ZombieReinforcementEvent.java
 @@ -0,0 +1,52 @@
@@ -67,5 +67,5 @@ index 0000000..5e0a9bb
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0035-Persistent-and-Temporary-Metadata-API.patch
+++ b/patches/api/0035-Persistent-and-Temporary-Metadata-API.patch
@@ -1,26 +1,26 @@
-From a269aae1cec4c15ae78dd6844a3c64ded731e944 Mon Sep 17 00:00:00 2001
+From 22e06eb2a399c556b125eed6ff362f9f7e05a8b7 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 4 Jul 2013 21:04:26 -0400
 Subject: [PATCH] Persistent and Temporary Metadata API
 
 Entity, TileEntity, World, Chunk, Block, Inventory API's
 ---
- src/main/java/com/empireminecraft/api/API.java     |   2 +
- .../java/com/empireminecraft/api/Vector3i.java     |  66 ++
- .../com/empireminecraft/api/meta/EAPI_Meta.java    |  53 ++
- .../java/com/empireminecraft/api/meta/Meta.java    | 875 +++++++++++++++++++++
- .../java/com/empireminecraft/api/meta/MetaKey.java |  51 ++
- .../java/com/empireminecraft/api/meta/MetaMap.java |  96 +++
- .../api/meta/PersistentKeyImpl.java                |  44 ++
- .../api/meta/PersistentMetaList.java               |  73 ++
- .../api/meta/PersistentMetaMap.java                |  93 +++
- .../com/empireminecraft/api/meta/TempKeyImpl.java  |  44 ++
- .../com/empireminecraft/api/meta/TempMetaMap.java  |  29 +
- .../BlockWithPersistentMetaClearedEvent.java       |  49 ++
- src/main/java/org/bukkit/Chunk.java                |   2 +
- src/main/java/org/bukkit/block/BlockState.java     |   2 +
- src/main/java/org/bukkit/entity/Entity.java        |   1 +
- src/main/java/org/bukkit/inventory/Inventory.java  |   1 +
+ .../java/com/empireminecraft/api/API.java     |   2 +
+ .../com/empireminecraft/api/Vector3i.java     |  66 ++
+ .../empireminecraft/api/meta/EAPI_Meta.java   |  53 ++
+ .../com/empireminecraft/api/meta/Meta.java    | 875 ++++++++++++++++++
+ .../com/empireminecraft/api/meta/MetaKey.java |  51 +
+ .../com/empireminecraft/api/meta/MetaMap.java |  96 ++
+ .../api/meta/PersistentKeyImpl.java           |  44 +
+ .../api/meta/PersistentMetaList.java          |  73 ++
+ .../api/meta/PersistentMetaMap.java           |  93 ++
+ .../empireminecraft/api/meta/TempKeyImpl.java |  44 +
+ .../empireminecraft/api/meta/TempMetaMap.java |  29 +
+ .../BlockWithPersistentMetaClearedEvent.java  |  49 +
+ src/main/java/org/bukkit/Chunk.java           |   2 +
+ .../java/org/bukkit/block/BlockState.java     |   2 +
+ src/main/java/org/bukkit/entity/Entity.java   |   1 +
+ .../java/org/bukkit/inventory/Inventory.java  |   1 +
  16 files changed, 1481 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/api/Vector3i.java
  create mode 100644 src/main/java/com/empireminecraft/api/meta/EAPI_Meta.java
@@ -35,7 +35,7 @@ Entity, TileEntity, World, Chunk, Block, Inventory API's
  create mode 100644 src/main/java/com/empireminecraft/customevents/BlockWithPersistentMetaClearedEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/api/API.java b/src/main/java/com/empireminecraft/api/API.java
-index 237e557..9ff1db8 100644
+index 237e5575..9ff1db8c 100644
 --- a/src/main/java/com/empireminecraft/api/API.java
 +++ b/src/main/java/com/empireminecraft/api/API.java
 @@ -23,12 +23,14 @@
@@ -55,7 +55,7 @@ index 237e557..9ff1db8 100644
          return ExceptionUtils.getFullStackTrace(new Throwable());
 diff --git a/src/main/java/com/empireminecraft/api/Vector3i.java b/src/main/java/com/empireminecraft/api/Vector3i.java
 new file mode 100644
-index 0000000..75b2748
+index 00000000..75b2748e
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/Vector3i.java
 @@ -0,0 +1,66 @@
@@ -127,7 +127,7 @@ index 0000000..75b2748
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/EAPI_Meta.java b/src/main/java/com/empireminecraft/api/meta/EAPI_Meta.java
 new file mode 100644
-index 0000000..8313735
+index 00000000..8313735b
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/EAPI_Meta.java
 @@ -0,0 +1,53 @@
@@ -186,7 +186,7 @@ index 0000000..8313735
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/Meta.java b/src/main/java/com/empireminecraft/api/meta/Meta.java
 new file mode 100644
-index 0000000..ecd8f90
+index 00000000..ecd8f909
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/Meta.java
 @@ -0,0 +1,875 @@
@@ -1067,7 +1067,7 @@ index 0000000..ecd8f90
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/MetaKey.java b/src/main/java/com/empireminecraft/api/meta/MetaKey.java
 new file mode 100644
-index 0000000..f0b62b4
+index 00000000..f0b62b48
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/MetaKey.java
 @@ -0,0 +1,51 @@
@@ -1124,7 +1124,7 @@ index 0000000..f0b62b4
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/MetaMap.java b/src/main/java/com/empireminecraft/api/meta/MetaMap.java
 new file mode 100644
-index 0000000..a47f013
+index 00000000..a47f0130
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/MetaMap.java
 @@ -0,0 +1,96 @@
@@ -1226,7 +1226,7 @@ index 0000000..a47f013
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/PersistentKeyImpl.java b/src/main/java/com/empireminecraft/api/meta/PersistentKeyImpl.java
 new file mode 100644
-index 0000000..0d62fbf
+index 00000000..0d62fbf0
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/PersistentKeyImpl.java
 @@ -0,0 +1,44 @@
@@ -1276,7 +1276,7 @@ index 0000000..0d62fbf
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/PersistentMetaList.java b/src/main/java/com/empireminecraft/api/meta/PersistentMetaList.java
 new file mode 100644
-index 0000000..e406025
+index 00000000..e4060252
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/PersistentMetaList.java
 @@ -0,0 +1,73 @@
@@ -1355,7 +1355,7 @@ index 0000000..e406025
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/PersistentMetaMap.java b/src/main/java/com/empireminecraft/api/meta/PersistentMetaMap.java
 new file mode 100644
-index 0000000..f45c34c
+index 00000000..f45c34cc
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/PersistentMetaMap.java
 @@ -0,0 +1,93 @@
@@ -1454,7 +1454,7 @@ index 0000000..f45c34c
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/TempKeyImpl.java b/src/main/java/com/empireminecraft/api/meta/TempKeyImpl.java
 new file mode 100644
-index 0000000..d3de862
+index 00000000..d3de8624
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/TempKeyImpl.java
 @@ -0,0 +1,44 @@
@@ -1504,7 +1504,7 @@ index 0000000..d3de862
 +}
 diff --git a/src/main/java/com/empireminecraft/api/meta/TempMetaMap.java b/src/main/java/com/empireminecraft/api/meta/TempMetaMap.java
 new file mode 100644
-index 0000000..8177936
+index 00000000..8177936f
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/TempMetaMap.java
 @@ -0,0 +1,29 @@
@@ -1539,7 +1539,7 @@ index 0000000..8177936
 +}
 diff --git a/src/main/java/com/empireminecraft/customevents/BlockWithPersistentMetaClearedEvent.java b/src/main/java/com/empireminecraft/customevents/BlockWithPersistentMetaClearedEvent.java
 new file mode 100644
-index 0000000..4963d24
+index 00000000..4963d24f
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/BlockWithPersistentMetaClearedEvent.java
 @@ -0,0 +1,49 @@
@@ -1593,7 +1593,7 @@ index 0000000..4963d24
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 0abd437..53322af 100644
+index 0abd4377..53322af7 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
 @@ -122,6 +122,8 @@ public interface Chunk {
@@ -1606,7 +1606,7 @@ index 0abd437..53322af 100644
       * Checks if the chunk is loaded.
       *
 diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
-index 631cbf2..de02763 100644
+index 631cbf2b..de027639 100644
 --- a/src/main/java/org/bukkit/block/BlockState.java
 +++ b/src/main/java/org/bukkit/block/BlockState.java
 @@ -221,4 +221,6 @@ public interface BlockState extends Metadatable {
@@ -1617,7 +1617,7 @@ index 631cbf2..de02763 100644
 +    boolean isTileEntity(); // EMC
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 8e98c53..04fdf23 100644
+index 8e98c53d..04fdf234 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -254,6 +254,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
@@ -1629,7 +1629,7 @@ index 8e98c53..04fdf23 100644
       * Returns true if the entity gets persisted.
       * <p>
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 730f6e0..898786c 100644
+index 730f6e0f..898786c2 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
 @@ -27,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
@@ -1641,5 +1641,5 @@ index 730f6e0..898786c 100644
       * Returns the size of the inventory
       *
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0036-Hopper-Events.patch
+++ b/patches/api/0036-Hopper-Events.patch
@@ -1,18 +1,18 @@
-From 9d6057191bba401934971063ee2b72f09e786af4 Mon Sep 17 00:00:00 2001
+From fa3c30b116e4a64806bac4953a1267cccec7ec94 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 20:21:12 -0500
 Subject: [PATCH] Hopper Events
 
 ---
- .../customevents/HopperDrainEvent.java             | 65 ++++++++++++++++++++
- .../customevents/HopperFillEvent.java              | 70 ++++++++++++++++++++++
+ .../customevents/HopperDrainEvent.java        | 65 +++++++++++++++++
+ .../customevents/HopperFillEvent.java         | 70 +++++++++++++++++++
  2 files changed, 135 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/HopperDrainEvent.java
  create mode 100644 src/main/java/com/empireminecraft/customevents/HopperFillEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/HopperDrainEvent.java b/src/main/java/com/empireminecraft/customevents/HopperDrainEvent.java
 new file mode 100644
-index 0000000..9b8e50a
+index 00000000..9b8e50ad
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/HopperDrainEvent.java
 @@ -0,0 +1,65 @@
@@ -83,7 +83,7 @@ index 0000000..9b8e50a
 +}
 diff --git a/src/main/java/com/empireminecraft/customevents/HopperFillEvent.java b/src/main/java/com/empireminecraft/customevents/HopperFillEvent.java
 new file mode 100644
-index 0000000..f60d676
+index 00000000..f60d6760
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/HopperFillEvent.java
 @@ -0,0 +1,70 @@
@@ -158,5 +158,5 @@ index 0000000..f60d676
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0037-SnowmanThrowSnowballEvent.patch
+++ b/patches/api/0037-SnowmanThrowSnowballEvent.patch
@@ -1,16 +1,16 @@
-From fb9c4d30368d59667b0ef2bb3ed9a5056ce5db6c Mon Sep 17 00:00:00 2001
+From ee498112f3740145590b48bc23d7a71ae4e5df66 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 20:28:24 -0500
 Subject: [PATCH] SnowmanThrowSnowballEvent
 
 ---
- .../customevents/SnowmanThrowSnowballEvent.java    | 63 ++++++++++++++++++++++
+ .../SnowmanThrowSnowballEvent.java            | 63 +++++++++++++++++++
  1 file changed, 63 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/SnowmanThrowSnowballEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/SnowmanThrowSnowballEvent.java b/src/main/java/com/empireminecraft/customevents/SnowmanThrowSnowballEvent.java
 new file mode 100644
-index 0000000..5331106
+index 00000000..53311062
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/SnowmanThrowSnowballEvent.java
 @@ -0,0 +1,63 @@
@@ -78,5 +78,5 @@ index 0000000..5331106
 +
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0038-Profile-Serialization-Events.patch
+++ b/patches/api/0038-Profile-Serialization-Events.patch
@@ -1,18 +1,18 @@
-From 9d12e4d5ac24fb8b6282463f23c07e53516cd4cf Mon Sep 17 00:00:00 2001
+From 7880b6c2238355edda17d58a88ba6d58a3200b81 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 21:50:15 -0500
 Subject: [PATCH] Profile Serialization Events
 
 ---
- .../customevents/ProfileDeserializeEvent.java      | 53 ++++++++++++++++++++++
- .../customevents/ProfileSerializeEvent.java        | 37 +++++++++++++++
+ .../customevents/ProfileDeserializeEvent.java | 53 +++++++++++++++++++
+ .../customevents/ProfileSerializeEvent.java   | 37 +++++++++++++
  2 files changed, 90 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/ProfileDeserializeEvent.java
  create mode 100644 src/main/java/com/empireminecraft/customevents/ProfileSerializeEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/ProfileDeserializeEvent.java b/src/main/java/com/empireminecraft/customevents/ProfileDeserializeEvent.java
 new file mode 100644
-index 0000000..02d3135
+index 00000000..02d31358
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/ProfileDeserializeEvent.java
 @@ -0,0 +1,53 @@
@@ -71,7 +71,7 @@ index 0000000..02d3135
 +}
 diff --git a/src/main/java/com/empireminecraft/customevents/ProfileSerializeEvent.java b/src/main/java/com/empireminecraft/customevents/ProfileSerializeEvent.java
 new file mode 100644
-index 0000000..f5c035f
+index 00000000..f5c035ff
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/ProfileSerializeEvent.java
 @@ -0,0 +1,37 @@
@@ -113,5 +113,5 @@ index 0000000..f5c035f
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0039-SendSignEvent.patch
+++ b/patches/api/0039-SendSignEvent.patch
@@ -1,16 +1,16 @@
-From f3dcc1faf9dfa85a84dbf1fbc84d627559927fe6 Mon Sep 17 00:00:00 2001
+From ebea1f1354f4c66d44d18c4184f7860a62f5f334 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 22:06:10 -0500
 Subject: [PATCH] SendSignEvent
 
 ---
- .../customevents/SendSignEvent.java                | 45 ++++++++++++++++++++++
+ .../customevents/SendSignEvent.java           | 45 +++++++++++++++++++
  1 file changed, 45 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/SendSignEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/SendSignEvent.java b/src/main/java/com/empireminecraft/customevents/SendSignEvent.java
 new file mode 100644
-index 0000000..c515591
+index 00000000..c5155915
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/SendSignEvent.java
 @@ -0,0 +1,45 @@
@@ -60,5 +60,5 @@ index 0000000..c515591
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0040-Chat-API.patch
+++ b/patches/api/0040-Chat-API.patch
@@ -1,16 +1,16 @@
-From f056848c6c87e4335db8c58eb80928282335287f Mon Sep 17 00:00:00 2001
+From e179c77c06afc3b3f7d1ad9fb9cf12d06ec5b539 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 22:30:15 -0500
 Subject: [PATCH] Chat API
 
 ---
- src/main/java/com/empireminecraft/api/API.java     |  1 +
- .../java/com/empireminecraft/api/EAPI_Chat.java    | 57 ++++++++++++++++++++++
+ .../java/com/empireminecraft/api/API.java     |  1 +
+ .../com/empireminecraft/api/EAPI_Chat.java    | 57 +++++++++++++++++++
  2 files changed, 58 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/api/EAPI_Chat.java
 
 diff --git a/src/main/java/com/empireminecraft/api/API.java b/src/main/java/com/empireminecraft/api/API.java
-index 9ff1db8..efa1e55 100644
+index 9ff1db8c..efa1e55e 100644
 --- a/src/main/java/com/empireminecraft/api/API.java
 +++ b/src/main/java/com/empireminecraft/api/API.java
 @@ -31,6 +31,7 @@ public abstract class API {
@@ -23,7 +23,7 @@ index 9ff1db8..efa1e55 100644
          return ExceptionUtils.getFullStackTrace(new Throwable());
 diff --git a/src/main/java/com/empireminecraft/api/EAPI_Chat.java b/src/main/java/com/empireminecraft/api/EAPI_Chat.java
 new file mode 100644
-index 0000000..96a845f
+index 00000000..96a845fb
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/EAPI_Chat.java
 @@ -0,0 +1,57 @@
@@ -85,5 +85,5 @@ index 0000000..96a845f
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0041-Entity-Tasks.patch
+++ b/patches/api/0041-Entity-Tasks.patch
@@ -1,16 +1,16 @@
-From a314d75c902f9e9bbbf7ece1ad787f20d179ad02 Mon Sep 17 00:00:00 2001
+From 7f7a95328dac713bad4d7375ff448c546364cff8 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 4 Dec 2016 22:52:29 -0500
 Subject: [PATCH] Entity Tasks
 
 ---
- .../java/com/empireminecraft/api/EAPI_Entity.java  |  59 ++++++++++++
- .../java/com/empireminecraft/api/EntityTask.java   | 106 +++++++++++++++++++++
+ .../com/empireminecraft/api/EAPI_Entity.java  |  59 ++++++++++
+ .../com/empireminecraft/api/EntityTask.java   | 106 ++++++++++++++++++
  2 files changed, 165 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/api/EntityTask.java
 
 diff --git a/src/main/java/com/empireminecraft/api/EAPI_Entity.java b/src/main/java/com/empireminecraft/api/EAPI_Entity.java
-index 8180ce4..4ef15c9 100644
+index 8180ce46..4ef15c90 100644
 --- a/src/main/java/com/empireminecraft/api/EAPI_Entity.java
 +++ b/src/main/java/com/empireminecraft/api/EAPI_Entity.java
 @@ -23,6 +23,7 @@
@@ -86,7 +86,7 @@ index 8180ce4..4ef15c9 100644
  }
 diff --git a/src/main/java/com/empireminecraft/api/EntityTask.java b/src/main/java/com/empireminecraft/api/EntityTask.java
 new file mode 100644
-index 0000000..ea0dd35
+index 00000000..ea0dd351
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/EntityTask.java
 @@ -0,0 +1,106 @@
@@ -197,5 +197,5 @@ index 0000000..ea0dd35
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0042-Attributes-API.patch
+++ b/patches/api/0042-Attributes-API.patch
@@ -1,14 +1,14 @@
-From d0957bd4462580615e25d1ecda1ccdc91074dcc0 Mon Sep 17 00:00:00 2001
+From f255389f95c856c89c4378c7c2663368263de737 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 6 Dec 2016 22:31:31 -0500
 Subject: [PATCH] Attributes API
 
 ---
- src/main/java/com/empireminecraft/api/API.java     |   2 +
- .../empireminecraft/api/attributes/Attribute.java  |  46 +++++++
- .../api/attributes/AttributeSlot.java              |  81 +++++++++++++
- .../api/attributes/EAPI_Attributes.java            | 134 +++++++++++++++++++++
- .../empireminecraft/api/attributes/Operation.java  |  50 ++++++++
+ .../java/com/empireminecraft/api/API.java     |   2 +
+ .../api/attributes/Attribute.java             |  46 ++++++
+ .../api/attributes/AttributeSlot.java         |  81 +++++++++++
+ .../api/attributes/EAPI_Attributes.java       | 134 ++++++++++++++++++
+ .../api/attributes/Operation.java             |  50 +++++++
  5 files changed, 313 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/api/attributes/Attribute.java
  create mode 100644 src/main/java/com/empireminecraft/api/attributes/AttributeSlot.java
@@ -16,7 +16,7 @@ Subject: [PATCH] Attributes API
  create mode 100644 src/main/java/com/empireminecraft/api/attributes/Operation.java
 
 diff --git a/src/main/java/com/empireminecraft/api/API.java b/src/main/java/com/empireminecraft/api/API.java
-index efa1e55..4197eb1 100644
+index efa1e55e..4197eb10 100644
 --- a/src/main/java/com/empireminecraft/api/API.java
 +++ b/src/main/java/com/empireminecraft/api/API.java
 @@ -23,6 +23,7 @@
@@ -37,7 +37,7 @@ index efa1e55..4197eb1 100644
          return ExceptionUtils.getFullStackTrace(new Throwable());
 diff --git a/src/main/java/com/empireminecraft/api/attributes/Attribute.java b/src/main/java/com/empireminecraft/api/attributes/Attribute.java
 new file mode 100644
-index 0000000..1266c97
+index 00000000..1266c97e
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/attributes/Attribute.java
 @@ -0,0 +1,46 @@
@@ -89,7 +89,7 @@ index 0000000..1266c97
 +}
 diff --git a/src/main/java/com/empireminecraft/api/attributes/AttributeSlot.java b/src/main/java/com/empireminecraft/api/attributes/AttributeSlot.java
 new file mode 100644
-index 0000000..b880757
+index 00000000..b8807576
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/attributes/AttributeSlot.java
 @@ -0,0 +1,81 @@
@@ -176,7 +176,7 @@ index 0000000..b880757
 +}
 diff --git a/src/main/java/com/empireminecraft/api/attributes/EAPI_Attributes.java b/src/main/java/com/empireminecraft/api/attributes/EAPI_Attributes.java
 new file mode 100644
-index 0000000..d84099c
+index 00000000..d84099c2
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/attributes/EAPI_Attributes.java
 @@ -0,0 +1,134 @@
@@ -316,7 +316,7 @@ index 0000000..d84099c
 +}
 diff --git a/src/main/java/com/empireminecraft/api/attributes/Operation.java b/src/main/java/com/empireminecraft/api/attributes/Operation.java
 new file mode 100644
-index 0000000..a438499
+index 00000000..a4384991
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/attributes/Operation.java
 @@ -0,0 +1,50 @@
@@ -371,5 +371,5 @@ index 0000000..a438499
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0043-Entity-AI-API.patch
+++ b/patches/api/0043-Entity-AI-API.patch
@@ -1,17 +1,17 @@
-From f5b6af1504ae71bcbfd09ac3e46b6dd01545d46b Mon Sep 17 00:00:00 2001
+From d6e863738a7d2795e9e65bb93c81883fa7c87e45 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 6 Dec 2016 22:31:40 -0500
 Subject: [PATCH] Entity AI API
 
 ---
- .../java/com/empireminecraft/api/EAPI_Entity.java  | 64 ++++++++++++++++++++++
- src/main/java/org/bukkit/entity/Blaze.java         |  7 ++-
- src/main/java/org/bukkit/entity/EnderSignal.java   |  8 ++-
- src/main/java/org/bukkit/entity/Ghast.java         |  6 +-
+ .../com/empireminecraft/api/EAPI_Entity.java  | 64 +++++++++++++++++++
+ src/main/java/org/bukkit/entity/Blaze.java    |  7 +-
+ .../java/org/bukkit/entity/EnderSignal.java   |  8 ++-
+ src/main/java/org/bukkit/entity/Ghast.java    |  6 +-
  4 files changed, 81 insertions(+), 4 deletions(-)
 
 diff --git a/src/main/java/com/empireminecraft/api/EAPI_Entity.java b/src/main/java/com/empireminecraft/api/EAPI_Entity.java
-index 4ef15c9..cf6ca99 100644
+index 4ef15c90..cf6ca998 100644
 --- a/src/main/java/com/empireminecraft/api/EAPI_Entity.java
 +++ b/src/main/java/com/empireminecraft/api/EAPI_Entity.java
 @@ -23,9 +23,19 @@
@@ -94,7 +94,7 @@ index 4ef15c9..cf6ca99 100644
 +    void setEnderSignalDestination(@NotNull EnderSignal enderSignal, Location target);
  }
 diff --git a/src/main/java/org/bukkit/entity/Blaze.java b/src/main/java/org/bukkit/entity/Blaze.java
-index 7a5505b..5f4161c 100644
+index 7a5505b7..5f4161c8 100644
 --- a/src/main/java/org/bukkit/entity/Blaze.java
 +++ b/src/main/java/org/bukkit/entity/Blaze.java
 @@ -4,5 +4,10 @@ package org.bukkit.entity;
@@ -110,7 +110,7 @@ index 7a5505b..5f4161c 100644
 +    // EMC end
  }
 diff --git a/src/main/java/org/bukkit/entity/EnderSignal.java b/src/main/java/org/bukkit/entity/EnderSignal.java
-index e90bca8..eaaebe3 100644
+index e90bca82..eaaebe32 100644
 --- a/src/main/java/org/bukkit/entity/EnderSignal.java
 +++ b/src/main/java/org/bukkit/entity/EnderSignal.java
 @@ -15,7 +15,7 @@ public interface EnderSignal extends Entity {
@@ -136,7 +136,7 @@ index e90bca8..eaaebe3 100644
      /**
       * Gets if the EnderSignal should drop an item on death.<br>
 diff --git a/src/main/java/org/bukkit/entity/Ghast.java b/src/main/java/org/bukkit/entity/Ghast.java
-index 3f5edf7..324ac12 100644
+index 3f5edf76..324ac12e 100644
 --- a/src/main/java/org/bukkit/entity/Ghast.java
 +++ b/src/main/java/org/bukkit/entity/Ghast.java
 @@ -3,4 +3,8 @@ package org.bukkit.entity;
@@ -150,5 +150,5 @@ index 3f5edf7..324ac12 100644
 +    void setFireballCooldown(int cooldown); // EMC
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0044-PlayerUseItemEvent.patch
+++ b/patches/api/0044-PlayerUseItemEvent.patch
@@ -1,13 +1,13 @@
-From c15e983b37aa7860959147ef950d4949a2975229 Mon Sep 17 00:00:00 2001
+From adaab366f1814cdfec1c6ed289e48815cb00b880 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 7 Dec 2016 00:22:09 -0500
 Subject: [PATCH] PlayerUseItemEvent
 
 ---
- .../event/player/PlayerPostPlaceItemAtEvent.java   |  80 +++++++++++++++
- .../paper/event/player/PlayerPostUseItemEvent.java |  69 +++++++++++++
- .../customevents/PlayerPlaceItemAtEvent.java       | 110 +++++++++++++++++++++
- .../customevents/PlayerUseItemEvent.java           |  89 +++++++++++++++++
+ .../player/PlayerPostPlaceItemAtEvent.java    |  80 +++++++++++++
+ .../event/player/PlayerPostUseItemEvent.java  |  69 +++++++++++
+ .../customevents/PlayerPlaceItemAtEvent.java  | 110 ++++++++++++++++++
+ .../customevents/PlayerUseItemEvent.java      |  89 ++++++++++++++
  4 files changed, 348 insertions(+)
  create mode 100644 src/main/java/com/destroystokyo/paper/event/player/PlayerPostPlaceItemAtEvent.java
  create mode 100644 src/main/java/com/destroystokyo/paper/event/player/PlayerPostUseItemEvent.java
@@ -16,7 +16,7 @@ Subject: [PATCH] PlayerUseItemEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerPostPlaceItemAtEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostPlaceItemAtEvent.java
 new file mode 100644
-index 0000000..8e83d0d
+index 00000000..8e83d0d9
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostPlaceItemAtEvent.java
 @@ -0,0 +1,80 @@
@@ -102,7 +102,7 @@ index 0000000..8e83d0d
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerPostUseItemEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostUseItemEvent.java
 new file mode 100644
-index 0000000..511082e
+index 00000000..511082ea
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostUseItemEvent.java
 @@ -0,0 +1,69 @@
@@ -177,7 +177,7 @@ index 0000000..511082e
 +}
 diff --git a/src/main/java/com/empireminecraft/customevents/PlayerPlaceItemAtEvent.java b/src/main/java/com/empireminecraft/customevents/PlayerPlaceItemAtEvent.java
 new file mode 100644
-index 0000000..1b1bf85
+index 00000000..1b1bf854
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/PlayerPlaceItemAtEvent.java
 @@ -0,0 +1,110 @@
@@ -293,7 +293,7 @@ index 0000000..1b1bf85
 +}
 diff --git a/src/main/java/com/empireminecraft/customevents/PlayerUseItemEvent.java b/src/main/java/com/empireminecraft/customevents/PlayerUseItemEvent.java
 new file mode 100644
-index 0000000..c61c6a4
+index 00000000..c61c6a44
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/PlayerUseItemEvent.java
 @@ -0,0 +1,89 @@
@@ -387,5 +387,5 @@ index 0000000..c61c6a4
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0045-Villager-Treasure-Map-Events.patch
+++ b/patches/api/0045-Villager-Treasure-Map-Events.patch
@@ -1,16 +1,16 @@
-From d6a07419528b5ba8f7af88f9daebbd848f0e4228 Mon Sep 17 00:00:00 2001
+From 95879b16d49c789f78fa5177bc3882908551f1f4 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 13 Dec 2016 00:40:35 -0500
 Subject: [PATCH] Villager Treasure Map Events
 
 ---
- .../java/com/empireminecraft/api/EAPI_Misc.java    | 22 ++++++++
- .../CreatePendingTreasureMapEvent.java             | 65 ++++++++++++++++++++++
+ .../com/empireminecraft/api/EAPI_Misc.java    | 22 +++++++
+ .../CreatePendingTreasureMapEvent.java        | 65 +++++++++++++++++++
  2 files changed, 87 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/CreatePendingTreasureMapEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/api/EAPI_Misc.java b/src/main/java/com/empireminecraft/api/EAPI_Misc.java
-index 64e5591..fa4148a 100644
+index 64e55912..fa4148a9 100644
 --- a/src/main/java/com/empireminecraft/api/EAPI_Misc.java
 +++ b/src/main/java/com/empireminecraft/api/EAPI_Misc.java
 @@ -23,5 +23,27 @@
@@ -43,7 +43,7 @@ index 64e5591..fa4148a 100644
  }
 diff --git a/src/main/java/com/empireminecraft/customevents/CreatePendingTreasureMapEvent.java b/src/main/java/com/empireminecraft/customevents/CreatePendingTreasureMapEvent.java
 new file mode 100644
-index 0000000..00c6eff
+index 00000000..00c6eff9
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/CreatePendingTreasureMapEvent.java
 @@ -0,0 +1,65 @@
@@ -113,5 +113,5 @@ index 0000000..00c6eff
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0046-ShulkerBox-API.patch
+++ b/patches/api/0046-ShulkerBox-API.patch
@@ -1,14 +1,14 @@
-From 377aed3b057f1737e25c00d17ff01a3c76beb997 Mon Sep 17 00:00:00 2001
+From 7c579d8ed3e04e687ce3c4030cde928f5946b8fe Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 1 Jan 2017 20:35:55 -0500
 Subject: [PATCH] ShulkerBox API
 
 ---
- src/main/java/com/empireminecraft/api/EAPI_Misc.java | 18 ++++++++++++++++++
+ .../com/empireminecraft/api/EAPI_Misc.java     | 18 ++++++++++++++++++
  1 file changed, 18 insertions(+)
 
 diff --git a/src/main/java/com/empireminecraft/api/EAPI_Misc.java b/src/main/java/com/empireminecraft/api/EAPI_Misc.java
-index fa4148a..6c5a5b9 100644
+index fa4148a9..6c5a5b9c 100644
 --- a/src/main/java/com/empireminecraft/api/EAPI_Misc.java
 +++ b/src/main/java/com/empireminecraft/api/EAPI_Misc.java
 @@ -27,6 +27,8 @@ import org.bukkit.Location;
@@ -42,5 +42,5 @@ index fa4148a..6c5a5b9 100644
 +    List<ItemStack> getShulkerInventory(@Nonnull ItemStack shulker);
  }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0047-Add-ChatColor.getById.patch
+++ b/patches/api/0047-Add-ChatColor.getById.patch
@@ -1,4 +1,4 @@
-From c2c2ac1d7ab3451d04097551d7e331423980ca90 Mon Sep 17 00:00:00 2001
+From d420dec49890e216c0df1cd4e0c81009f203d73a Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 24 Apr 2017 20:27:23 -0400
 Subject: [PATCH] Add ChatColor.getById
@@ -9,13 +9,14 @@ Bukkit has had a map of this for years and it was totally unused...
  1 file changed, 20 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/ChatColor.java b/src/main/java/org/bukkit/ChatColor.java
-index b2c8294..b1aa18c 100644
+index b2c82940..b1aa18cc 100644
 --- a/src/main/java/org/bukkit/ChatColor.java
 +++ b/src/main/java/org/bukkit/ChatColor.java
-@@ -264,6 +264,15 @@ public enum ChatColor {
+@@ -263,6 +263,15 @@ public enum ChatColor {
+         return net.md_5.bungee.api.ChatColor.RESET;
      };
  
-     /**
++    /**
 +     * Gets the numeric ID associated with this color
 +     *
 +     * @return An int value of this color code
@@ -24,14 +25,14 @@ index b2c8294..b1aa18c 100644
 +        return intCode;
 +    }
 +
-+    /**
+     /**
       * Gets the char value associated with this color
       *
-      * @return A char value of this color code
-@@ -297,6 +306,17 @@ public enum ChatColor {
+@@ -296,6 +305,17 @@ public enum ChatColor {
+         return !isFormat && this != RESET;
      }
  
-     /**
++    /**
 +     * Gets the color represented by the specified color ID
 +     *
 +     * @param id Code to check
@@ -42,10 +43,9 @@ index b2c8294..b1aa18c 100644
 +        return BY_ID.get(id);
 +    }
 +
-+    /**
+     /**
       * Gets the color represented by the specified color code
       *
-      * @param code Code to check
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0048-EntityAttackedEntityEvent.patch
+++ b/patches/api/0048-EntityAttackedEntityEvent.patch
@@ -1,4 +1,4 @@
-From 8dcc783a9166295c1893386a109596def8d20686 Mon Sep 17 00:00:00 2001
+From 53a6ce221a3bac9710336ac5c62815cd1cc0428f Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 20 Dec 2017 21:55:16 -0500
 Subject: [PATCH] EntityAttackedEntityEvent
@@ -6,9 +6,9 @@ Subject: [PATCH] EntityAttackedEntityEvent
 For when you need to know one Entity has attacked another entity
 and that the damage event was not cancelled.
 ---
- .../event/entity/EntityAttackedEntityEvent.java    | 92 ++++++++++++++++++++++
- .../event/entity/EntityAttackedPlayerEvent.java    | 40 ++++++++++
- .../event/entity/PlayerAttackedEntityEvent.java    | 41 ++++++++++
+ .../entity/EntityAttackedEntityEvent.java     | 92 +++++++++++++++++++
+ .../entity/EntityAttackedPlayerEvent.java     | 40 ++++++++
+ .../entity/PlayerAttackedEntityEvent.java     | 41 +++++++++
  3 files changed, 173 insertions(+)
  create mode 100644 src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedEntityEvent.java
  create mode 100644 src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedPlayerEvent.java
@@ -16,7 +16,7 @@ and that the damage event was not cancelled.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedEntityEvent.java
 new file mode 100644
-index 0000000..0f32f15
+index 00000000..0f32f157
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedEntityEvent.java
 @@ -0,0 +1,92 @@
@@ -114,7 +114,7 @@ index 0000000..0f32f15
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedPlayerEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedPlayerEvent.java
 new file mode 100644
-index 0000000..8ce33f3
+index 00000000..8ce33f32
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityAttackedPlayerEvent.java
 @@ -0,0 +1,40 @@
@@ -160,7 +160,7 @@ index 0000000..8ce33f3
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/PlayerAttackedEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/PlayerAttackedEntityEvent.java
 new file mode 100644
-index 0000000..134a7e0
+index 00000000..134a7e02
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/PlayerAttackedEntityEvent.java
 @@ -0,0 +1,41 @@
@@ -206,5 +206,5 @@ index 0000000..134a7e0
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0049-EnderSignalArriveEvent.patch
+++ b/patches/api/0049-EnderSignalArriveEvent.patch
@@ -1,16 +1,16 @@
-From edd58e3237ff703a8292255345a4a122acd66539 Mon Sep 17 00:00:00 2001
+From 7578c8c50a2a3b80431cd0d3688001356cb85cf0 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 10 May 2018 20:24:05 -0400
 Subject: [PATCH] EnderSignalArriveEvent
 
 ---
- .../customevents/EnderSignalArriveEvent.java       | 58 ++++++++++++++++++++++
+ .../customevents/EnderSignalArriveEvent.java  | 58 +++++++++++++++++++
  1 file changed, 58 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/EnderSignalArriveEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/EnderSignalArriveEvent.java b/src/main/java/com/empireminecraft/customevents/EnderSignalArriveEvent.java
 new file mode 100644
-index 0000000..3ee5dc4
+index 00000000..3ee5dc42
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/EnderSignalArriveEvent.java
 @@ -0,0 +1,58 @@
@@ -73,5 +73,5 @@ index 0000000..3ee5dc4
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0050-BlazeLaunchFireballEvent.patch
+++ b/patches/api/0050-BlazeLaunchFireballEvent.patch
@@ -1,16 +1,16 @@
-From e4df2f20124f6d002ce8373d05fc7b84acab2be4 Mon Sep 17 00:00:00 2001
+From b19800bee7c3e86eea8ca28ec3825aafde7383a3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 10 May 2018 20:25:37 -0400
 Subject: [PATCH] BlazeLaunchFireballEvent
 
 ---
- .../customevents/BlazeLaunchFireballEvent.java     | 66 ++++++++++++++++++++++
+ .../BlazeLaunchFireballEvent.java             | 66 +++++++++++++++++++
  1 file changed, 66 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/BlazeLaunchFireballEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/BlazeLaunchFireballEvent.java b/src/main/java/com/empireminecraft/customevents/BlazeLaunchFireballEvent.java
 new file mode 100644
-index 0000000..029a1f9
+index 00000000..029a1f9a
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/BlazeLaunchFireballEvent.java
 @@ -0,0 +1,66 @@
@@ -81,5 +81,5 @@ index 0000000..029a1f9
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0052-EntityRandomStrollEvent.patch
+++ b/patches/api/0052-EntityRandomStrollEvent.patch
@@ -1,16 +1,16 @@
-From b3c61491ec3c324d990cfd7b4c670651022b6512 Mon Sep 17 00:00:00 2001
+From 8de5d786b97ab8c8435b8576bb2fe83d772a6aa2 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 25 Jun 2018 22:29:57 -0400
 Subject: [PATCH] EntityRandomStrollEvent
 
 ---
- .../event/entity/EntityRandomStrollEvent.java      | 85 ++++++++++++++++++++++
+ .../event/entity/EntityRandomStrollEvent.java | 85 +++++++++++++++++++
  1 file changed, 85 insertions(+)
  create mode 100644 src/main/java/com/destroystokyo/paper/event/entity/EntityRandomStrollEvent.java
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityRandomStrollEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityRandomStrollEvent.java
 new file mode 100644
-index 0000000..1a2fd63
+index 00000000..1a2fd63d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityRandomStrollEvent.java
 @@ -0,0 +1,85 @@
@@ -100,5 +100,5 @@ index 0000000..1a2fd63
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0053-EntityPrepForRangedAttack.patch
+++ b/patches/api/0053-EntityPrepForRangedAttack.patch
@@ -1,16 +1,16 @@
-From 5b61a933e36e1d2dc83d58f19ff274eb44b9d367 Mon Sep 17 00:00:00 2001
+From a7a62e5de38acf85079d2a965cf77279c374fe79 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 25 Jun 2018 22:56:18 -0400
 Subject: [PATCH] EntityPrepForRangedAttack
 
 ---
- .../event/entity/EntityPrepForRangedAttack.java    | 96 ++++++++++++++++++++++
+ .../entity/EntityPrepForRangedAttack.java     | 96 +++++++++++++++++++
  1 file changed, 96 insertions(+)
  create mode 100644 src/main/java/com/destroystokyo/paper/event/entity/EntityPrepForRangedAttack.java
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityPrepForRangedAttack.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityPrepForRangedAttack.java
 new file mode 100644
-index 0000000..9e22b3d
+index 00000000..9e22b3db
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityPrepForRangedAttack.java
 @@ -0,0 +1,96 @@
@@ -111,5 +111,5 @@ index 0000000..9e22b3d
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0054-EntityPathfindEndEvent.patch
+++ b/patches/api/0054-EntityPathfindEndEvent.patch
@@ -1,16 +1,16 @@
-From a7e0f9abcc2550829322238ee9d72e293c2b25ec Mon Sep 17 00:00:00 2001
+From 54a667d94a2f9a6956ca9af5c56f8e0b388ae86f Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 25 Jun 2018 23:16:41 -0400
 Subject: [PATCH] EntityPathfindEndEvent
 
 ---
- .../paper/event/entity/EntityPathfindEndEvent.java | 51 ++++++++++++++++++++++
+ .../event/entity/EntityPathfindEndEvent.java  | 51 +++++++++++++++++++
  1 file changed, 51 insertions(+)
  create mode 100644 src/main/java/com/destroystokyo/paper/event/entity/EntityPathfindEndEvent.java
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityPathfindEndEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityPathfindEndEvent.java
 new file mode 100644
-index 0000000..fc6eb9e
+index 00000000..fc6eb9e9
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityPathfindEndEvent.java
 @@ -0,0 +1,51 @@
@@ -66,5 +66,5 @@ index 0000000..fc6eb9e
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0055-Detect-async-meta-set.patch
+++ b/patches/api/0055-Detect-async-meta-set.patch
@@ -1,14 +1,14 @@
-From cb9ccc6155fd3f38b799f3039ce9438f704ebce5 Mon Sep 17 00:00:00 2001
+From 25f295febb7a2f1214e9d9f16faa26422474c4b7 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 30 Jun 2018 03:06:49 -0400
 Subject: [PATCH] Detect async meta set
 
 ---
- src/main/java/com/empireminecraft/api/meta/MetaMap.java | 12 ++++++++++++
+ .../java/com/empireminecraft/api/meta/MetaMap.java   | 12 ++++++++++++
  1 file changed, 12 insertions(+)
 
 diff --git a/src/main/java/com/empireminecraft/api/meta/MetaMap.java b/src/main/java/com/empireminecraft/api/meta/MetaMap.java
-index a47f013..2563b21 100644
+index a47f0130..2563b216 100644
 --- a/src/main/java/com/empireminecraft/api/meta/MetaMap.java
 +++ b/src/main/java/com/empireminecraft/api/meta/MetaMap.java
 @@ -23,11 +23,14 @@
@@ -43,5 +43,5 @@ index a47f013..2563b21 100644
          return containsKey(key.key());
      }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0056-Contextual-Identifer-API.patch
+++ b/patches/api/0056-Contextual-Identifer-API.patch
@@ -1,4 +1,4 @@
-From 75e0e6b78352665d2b03e162f22d05e588e4ec16 Mon Sep 17 00:00:00 2001
+From fc6e330b2f16dcd5abf8163d0c0c081968e4d27a Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 17 May 2016 19:38:55 -0400
 Subject: [PATCH] Contextual Identifer API
@@ -13,16 +13,16 @@ But we may want to store counting data by chunk, but also by Residence, and cach
 
 Objects represented by an Identifier, should be able to use them as their equal/hashcodes.
 ---
- src/main/java/com/empireminecraft/Identifier.java  | 13 +++++++++
- .../java/com/empireminecraft/UniqueIdentifier.java | 34 ++++++++++++++++++++++
- src/main/java/org/bukkit/Chunk.java                |  1 +
+ .../java/com/empireminecraft/Identifier.java  | 13 +++++++
+ .../com/empireminecraft/UniqueIdentifier.java | 34 +++++++++++++++++++
+ src/main/java/org/bukkit/Chunk.java           |  1 +
  3 files changed, 48 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/Identifier.java
  create mode 100644 src/main/java/com/empireminecraft/UniqueIdentifier.java
 
 diff --git a/src/main/java/com/empireminecraft/Identifier.java b/src/main/java/com/empireminecraft/Identifier.java
 new file mode 100644
-index 0000000..188c344
+index 00000000..188c3449
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/Identifier.java
 @@ -0,0 +1,13 @@
@@ -41,7 +41,7 @@ index 0000000..188c344
 +public interface Identifier {}
 diff --git a/src/main/java/com/empireminecraft/UniqueIdentifier.java b/src/main/java/com/empireminecraft/UniqueIdentifier.java
 new file mode 100644
-index 0000000..423b003
+index 00000000..423b0034
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/UniqueIdentifier.java
 @@ -0,0 +1,34 @@
@@ -80,7 +80,7 @@ index 0000000..423b003
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 53322af..63e9955 100644
+index 53322af7..63e9955e 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
 @@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
@@ -92,5 +92,5 @@ index 53322af..63e9955 100644
      /**
       * Gets the X-coordinate of this chunk
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0057-Use-Version-plugin-files-so-can-keep-1.12-and-1.14-f.patch
+++ b/patches/api/0057-Use-Version-plugin-files-so-can-keep-1.12-and-1.14-f.patch
@@ -1,15 +1,15 @@
-From 4c355379d6001c7f9c5d19843ad4017a882eb90c Mon Sep 17 00:00:00 2001
+From 40e1030f993d6fbc0df7781a7d8bc65f0e929a01 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 6 Aug 2018 23:57:34 -0400
 Subject: [PATCH] Use Version plugin files so can keep 1.12 and 1.14 folders
  active
 
 ---
- src/main/java/org/bukkit/plugin/SimplePluginManager.java | 11 +++++++++++
+ .../java/org/bukkit/plugin/SimplePluginManager.java   | 11 +++++++++++
  1 file changed, 11 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index d0e735b..e1e2e79 100644
+index d0e735bc..e1e2e79d 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 @@ -110,6 +110,7 @@ public final class SimplePluginManager implements PluginManager {
@@ -38,5 +38,5 @@ index d0e735b..e1e2e79 100644
              for (Pattern filter : filters) {
                  Matcher match = filter.matcher(file.getName());
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0058-SpawnEggMeta-setSpawnedEntity-API.patch
+++ b/patches/api/0058-SpawnEggMeta-setSpawnedEntity-API.patch
@@ -1,4 +1,4 @@
-From 00aa5887a0084f61e8545c71cb63bf91e21bdd38 Mon Sep 17 00:00:00 2001
+From d4fa64cf60f30613e569f61412b9f5b21973ad98 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 18 Aug 2018 21:09:39 -0400
 Subject: [PATCH] SpawnEggMeta#setSpawnedEntity API
@@ -7,11 +7,11 @@ lets you copy an entities data into a spawn egg.
 Partial data is supported through a predicate, letting MC
 follow normal spawn behavior in the summon phase.
 ---
- .../org/bukkit/inventory/meta/SpawnEggMeta.java    | 39 ++++++++++++++++++++++
+ .../bukkit/inventory/meta/SpawnEggMeta.java   | 39 +++++++++++++++++++
  1 file changed, 39 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java b/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java
-index 9ae84de..f6ee31c 100644
+index 9ae84de4..f6ee31cd 100644
 --- a/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java
 @@ -9,6 +9,45 @@ import org.jetbrains.annotations.NotNull;
@@ -61,5 +61,5 @@ index 9ae84de..f6ee31c 100644
       * Get the type of entity this egg will spawn.
       *
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0059-Add-API-to-skip-checking-names-for-exact-stack-match.patch
+++ b/patches/api/0059-Add-API-to-skip-checking-names-for-exact-stack-match.patch
@@ -1,16 +1,16 @@
-From cc9ffc0f0f4ee87ccd5d1d5ebdca05083be4e237 Mon Sep 17 00:00:00 2001
+From 51409686d926b98cc9ef29f337cb980c0bf024e7 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 16 Jan 2019 21:29:20 -0500
 Subject: [PATCH] Add API to skip checking names for exact stack matches
 
 ---
- src/main/java/org/bukkit/inventory/RecipeChoice.java    | 12 +++++++++++-
- src/main/java/org/bukkit/inventory/ShapedRecipe.java    |  3 +++
- src/main/java/org/bukkit/inventory/ShapelessRecipe.java | 14 ++++++++++++--
+ .../java/org/bukkit/inventory/RecipeChoice.java    | 12 +++++++++++-
+ .../java/org/bukkit/inventory/ShapedRecipe.java    |  3 +++
+ .../java/org/bukkit/inventory/ShapelessRecipe.java | 14 ++++++++++++--
  3 files changed, 26 insertions(+), 3 deletions(-)
 
 diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-index 52c40fe..6ed3c69 100644
+index 52c40fe2..6ed3c697 100644
 --- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
 +++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
 @@ -164,7 +164,17 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
@@ -41,7 +41,7 @@ index 52c40fe..6ed3c69 100644
                  }
              }
 diff --git a/src/main/java/org/bukkit/inventory/ShapedRecipe.java b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
-index 222a12b..aeeb5e2 100644
+index 222a12ba..aeeb5e22 100644
 --- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
 @@ -150,6 +150,9 @@ public class ShapedRecipe implements Recipe, Keyed {
@@ -55,7 +55,7 @@ index 222a12b..aeeb5e2 100644
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
-index ddcf84e..3bd4166 100644
+index ddcf84e6..3bd41667 100644
 --- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 @@ -146,14 +146,24 @@ public class ShapelessRecipe implements Recipe, Keyed {
@@ -86,5 +86,5 @@ index ddcf84e..3bd4166 100644
          return this;
      }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0060-amend-ensureServerConversions.patch
+++ b/patches/api/0060-amend-ensureServerConversions.patch
@@ -1,16 +1,16 @@
-From 5bbd611947da15a964b19f58687f44feea282e2f Mon Sep 17 00:00:00 2001
+From 9cf51b3ae8d91f1fb28fa7c85fe57695dfc1784a Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 29 Mar 2019 21:45:09 -0400
 Subject: [PATCH] amend ensureServerConversions
 
 pending paper merge, store data version on stacks
 ---
- .../java/org/bukkit/inventory/ItemFactory.java     | 17 ++++++----
- src/main/java/org/bukkit/inventory/ItemStack.java  | 38 ++++++++++++++++++----
+ .../org/bukkit/inventory/ItemFactory.java     | 17 ++++++---
+ .../java/org/bukkit/inventory/ItemStack.java  | 38 ++++++++++++++++---
  2 files changed, 43 insertions(+), 12 deletions(-)
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 03ba226..32d2ce3 100644
+index 03ba2265..32d2ce35 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -144,13 +144,18 @@ public interface ItemFactory {
@@ -39,7 +39,7 @@ index 03ba226..32d2ce3 100644
      @NotNull
      ItemStack ensureServerConversions(@NotNull ItemStack item);
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 43f8108..e0ca0ec 100644
+index 43f81082..e0ca0ecd 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -26,6 +26,31 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
@@ -111,5 +111,5 @@ index 43f8108..e0ca0ec 100644
      @NotNull
      public ItemStack ensureServerConversions() {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/api/0061-Add-ConduitNewTargetEvent.patch
+++ b/patches/api/0061-Add-ConduitNewTargetEvent.patch
@@ -1,16 +1,16 @@
-From ae5fbf272156196b09cffd99b85f1e2970accae7 Mon Sep 17 00:00:00 2001
+From 19f54d2331f1f318961f387ab765a6822cfdf0a0 Mon Sep 17 00:00:00 2001
 From: chickeneer <emcchickeneer@gmail.com>
 Date: Sun, 14 Jul 2019 13:50:18 -0500
 Subject: [PATCH] Add ConduitNewTargetEvent
 
 ---
- .../customevents/ConduitNewTargetEvent.java        | 39 ++++++++++++++++++++++
+ .../customevents/ConduitNewTargetEvent.java   | 39 +++++++++++++++++++
  1 file changed, 39 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/customevents/ConduitNewTargetEvent.java
 
 diff --git a/src/main/java/com/empireminecraft/customevents/ConduitNewTargetEvent.java b/src/main/java/com/empireminecraft/customevents/ConduitNewTargetEvent.java
 new file mode 100644
-index 0000000..c3de31c
+index 00000000..c3de31cf
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/customevents/ConduitNewTargetEvent.java
 @@ -0,0 +1,39 @@
@@ -54,5 +54,5 @@ index 0000000..c3de31c
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0001-EmpireCraft-POM-Changes.patch
+++ b/patches/server/0001-EmpireCraft-POM-Changes.patch
@@ -1,15 +1,15 @@
-From 93f00e90df9e975d61e19d5ad764d4e900b25cd4 Mon Sep 17 00:00:00 2001
+From 6e0375205a4789683efc8b7db27933f8f0bc15cf Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 31 Oct 2012 23:26:58 -0400
 Subject: [PATCH] EmpireCraft POM Changes
 
 ---
- pom.xml                                            | 87 +++++++++++++++++++---
- .../org/bukkit/craftbukkit/util/Versioning.java    |  2 +-
+ pom.xml                                       | 87 ++++++++++++++++---
+ .../bukkit/craftbukkit/util/Versioning.java   |  2 +-
  2 files changed, 78 insertions(+), 11 deletions(-)
 
 diff --git a/pom.xml b/pom.xml
-index beda5dc..349d652 100644
+index beda5dc8a..349d65224 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,10 +1,10 @@
@@ -25,7 +25,7 @@ index beda5dc..349d652 100644
      <url>https://papermc.io</url>
  
      <properties>
-@@ -21,20 +21,83 @@
+@@ -21,19 +21,82 @@
      </properties>
  
      <parent>
@@ -46,7 +46,7 @@ index beda5dc..349d652 100644
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
-         <dependency>
++        <dependency>
 +            <groupId>com.zaxxer</groupId>
 +            <artifactId>HikariCP</artifactId>
 +            <version>2.4.1</version>
@@ -109,10 +109,9 @@ index beda5dc..349d652 100644
 +            <artifactId>json</artifactId>
 +            <version>20090211</version>
 +        </dependency>
-+        <dependency>
+         <dependency>
              <groupId>org.spigotmc</groupId>
              <artifactId>minecraft-server</artifactId>
-             <version>${minecraft.version}-SNAPSHOT</version>
 @@ -129,8 +192,12 @@
              Please see https://www.spigotmc.org/go/maven for more information.
          -->
@@ -140,7 +139,7 @@ index beda5dc..349d652 100644
              <plugin>
                  <groupId>com.lukegb.mojo</groupId>
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
-index 674096c..0f7a5ab 100644
+index 674096cab..0f7a5ab70 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 @@ -11,7 +11,7 @@ public final class Versioning {
@@ -153,5 +152,5 @@ index 674096c..0f7a5ab 100644
  
          if (stream != null) {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0002-MC-Log-utils.patch
+++ b/patches/server/0002-MC-Log-utils.patch
@@ -1,16 +1,16 @@
-From 1f3a940712b621348ae4115ec4d5bfdf893e6c77 Mon Sep 17 00:00:00 2001
+From 1bf7b62424d12a93be4747200e66cebd6e9b98f2 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 10 Dec 2016 14:00:25 -0500
 Subject: [PATCH] MC Log utils
 
 ---
- src/main/java/net/minecraft/server/MCLog.java | 77 +++++++++++++++++++++++++++
+ src/main/java/net/minecraft/server/MCLog.java | 77 +++++++++++++++++++
  1 file changed, 77 insertions(+)
  create mode 100644 src/main/java/net/minecraft/server/MCLog.java
 
 diff --git a/src/main/java/net/minecraft/server/MCLog.java b/src/main/java/net/minecraft/server/MCLog.java
 new file mode 100644
-index 0000000..bf28f00
+index 000000000..bf28f00db
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/MCLog.java
 @@ -0,0 +1,77 @@
@@ -92,5 +92,5 @@ index 0000000..bf28f00
 +
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0003-Misc-EMC-Changes.patch
+++ b/patches/server/0003-Misc-EMC-Changes.patch
@@ -1,4 +1,4 @@
-From 35557ec5244d22b76463d0eb08cc8db7cce95944 Mon Sep 17 00:00:00 2001
+From 08a6da84d63dc288f0751f86b3a082f9136b0cfd Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 22 Nov 2012 21:30:59 -0500
 Subject: [PATCH] Misc EMC Changes
@@ -15,17 +15,17 @@ Supress empty itemstack log messages
 Bat's with Passengers won't sleep
 Disable thorns for arrows
 ---
- src/main/java/net/minecraft/server/EntityArrow.java           |  2 +-
- src/main/java/net/minecraft/server/EntityBat.java             |  2 +-
- src/main/java/net/minecraft/server/EntityOcelot.java          |  2 +-
- src/main/java/net/minecraft/server/ItemStack.java             | 11 ++++++++++-
- .../java/net/minecraft/server/PathfinderGoalBreakDoor.java    |  2 +-
- src/main/java/net/minecraft/server/PropertyManager.java       |  2 +-
- .../java/org/bukkit/craftbukkit/event/CraftEventFactory.java  |  2 ++
+ src/main/java/net/minecraft/server/EntityArrow.java   |  2 +-
+ src/main/java/net/minecraft/server/EntityBat.java     |  2 +-
+ src/main/java/net/minecraft/server/EntityOcelot.java  |  2 +-
+ src/main/java/net/minecraft/server/ItemStack.java     | 11 ++++++++++-
+ .../net/minecraft/server/PathfinderGoalBreakDoor.java |  2 +-
+ .../java/net/minecraft/server/PropertyManager.java    |  2 +-
+ .../bukkit/craftbukkit/event/CraftEventFactory.java   |  2 ++
  7 files changed, 17 insertions(+), 6 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
-index 5f3e1cc..1f1f1cb 100644
+index 5f3e1ccb4..1f1f1cbab 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
 @@ -390,7 +390,7 @@ public abstract class EntityArrow extends Entity implements IProjectile {
@@ -38,7 +38,7 @@ index 5f3e1cc..1f1f1cb 100644
                  }
  
 diff --git a/src/main/java/net/minecraft/server/EntityBat.java b/src/main/java/net/minecraft/server/EntityBat.java
-index 7247421..3bc9f0d 100644
+index 72474211b..3bc9f0dd7 100644
 --- a/src/main/java/net/minecraft/server/EntityBat.java
 +++ b/src/main/java/net/minecraft/server/EntityBat.java
 @@ -144,7 +144,7 @@ public class EntityBat extends EntityAmbient {
@@ -51,7 +51,7 @@ index 7247421..3bc9f0d 100644
                  }
                  // CraftBukkit End
 diff --git a/src/main/java/net/minecraft/server/EntityOcelot.java b/src/main/java/net/minecraft/server/EntityOcelot.java
-index edc5f69..c4dac6d 100644
+index edc5f696c..c4dac6d84 100644
 --- a/src/main/java/net/minecraft/server/EntityOcelot.java
 +++ b/src/main/java/net/minecraft/server/EntityOcelot.java
 @@ -10,7 +10,7 @@ public class EntityOcelot extends EntityAnimal {
@@ -64,7 +64,7 @@ index edc5f69..c4dac6d 100644
      public EntityOcelot(EntityTypes<? extends EntityOcelot> entitytypes, World world) {
          super(entitytypes, world);
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index 0e16484..c6600aa 100644
+index 0e164840f..c6600aa14 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -396,7 +396,16 @@ public final class ItemStack {
@@ -94,7 +94,7 @@ index 0e16484..c6600aa 100644
                      if (event.isCancelled()) {
                          return false;
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java b/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java
-index 584b35e..3f496f2 100644
+index 584b35e1d..3f496f236 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java
 @@ -65,7 +65,7 @@ public class PathfinderGoalBreakDoor extends PathfinderGoalDoorInteract {
@@ -107,7 +107,7 @@ index 584b35e..3f496f2 100644
              if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityBreakDoorEvent(this.entity, this.door).isCancelled()) {
                  this.c();
 diff --git a/src/main/java/net/minecraft/server/PropertyManager.java b/src/main/java/net/minecraft/server/PropertyManager.java
-index 729455c..d12e275 100644
+index 729455ce5..d12e2757e 100644
 --- a/src/main/java/net/minecraft/server/PropertyManager.java
 +++ b/src/main/java/net/minecraft/server/PropertyManager.java
 @@ -75,7 +75,7 @@ public abstract class PropertyManager<T extends PropertyManager<T>> {
@@ -120,7 +120,7 @@ index 729455c..d12e275 100644
              }
              // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4074100..2399656 100644
+index 4074100c4..2399656a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -323,6 +323,7 @@ public class CraftEventFactory {
@@ -140,5 +140,5 @@ index 4074100..2399656 100644
      }
  
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0004-Empire-API.patch
+++ b/patches/server/0004-Empire-API.patch
@@ -1,13 +1,13 @@
-From 4319e339cd02217413185ceecad4b7e1ce471b67 Mon Sep 17 00:00:00 2001
+From bdb7422689de128a4e24014b2e8199ac47e51b12 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 3 Dec 2016 22:21:28 -0500
 Subject: [PATCH] Empire API
 
 ---
- .../com/empireminecraft/api/CraftEAPI_Entity.java  | 27 ++++++++++++++++
- .../com/empireminecraft/api/CraftEAPI_Misc.java    | 27 ++++++++++++++++
- .../com/empireminecraft/api/CraftEmpireAPI.java    | 36 ++++++++++++++++++++++
- .../java/org/bukkit/craftbukkit/CraftServer.java   |  1 +
+ .../empireminecraft/api/CraftEAPI_Entity.java | 27 ++++++++++++++
+ .../empireminecraft/api/CraftEAPI_Misc.java   | 27 ++++++++++++++
+ .../empireminecraft/api/CraftEmpireAPI.java   | 36 +++++++++++++++++++
+ .../org/bukkit/craftbukkit/CraftServer.java   |  1 +
  4 files changed, 91 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
  create mode 100644 src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
@@ -15,7 +15,7 @@ Subject: [PATCH] Empire API
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 new file mode 100644
-index 0000000..e7bb900
+index 000000000..e7bb9003d
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 @@ -0,0 +1,27 @@
@@ -48,7 +48,7 @@ index 0000000..e7bb900
 +}
 diff --git a/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java b/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
 new file mode 100644
-index 0000000..fa8cbd5
+index 000000000..fa8cbd5a3
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
 @@ -0,0 +1,27 @@
@@ -81,7 +81,7 @@ index 0000000..fa8cbd5
 +}
 diff --git a/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 new file mode 100644
-index 0000000..7b295bc
+index 000000000..7b295bc86
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 @@ -0,0 +1,36 @@
@@ -122,7 +122,7 @@ index 0000000..7b295bc
 +
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7a8ab7d..b6579ab 100644
+index 7a8ab7d40..b6579abc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -238,6 +238,7 @@ public final class CraftServer implements Server {
@@ -134,5 +134,5 @@ index 7a8ab7d..b6579ab 100644
          CraftItemFactory.instance();
      }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0005-SpawnerInitiateEvent.patch
+++ b/patches/server/0005-SpawnerInitiateEvent.patch
@@ -1,16 +1,16 @@
-From 530894879b04339894d9fb0fbd199090b2a7edc5 Mon Sep 17 00:00:00 2001
+From 4b7ce77558403634bec43a93eb96e6a30c5cdd4f Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 29 Nov 2012 10:48:07 -0500
 Subject: [PATCH] SpawnerInitiateEvent
 
 ---
- .../java/net/minecraft/server/EntityHuman.java     |  1 +
- .../java/net/minecraft/server/IEntityAccess.java   |  1 +
- .../net/minecraft/server/MobSpawnerAbstract.java   | 23 +++++++++++++++++++++-
+ .../net/minecraft/server/EntityHuman.java     |  1 +
+ .../net/minecraft/server/IEntityAccess.java   |  1 +
+ .../minecraft/server/MobSpawnerAbstract.java  | 23 ++++++++++++++++++-
  3 files changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 5d3e48b..b23cb52 100644
+index 5d3e48ba6..b23cb5282 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -73,6 +73,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -22,7 +22,7 @@ index 5d3e48b..b23cb52 100644
  
      // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/IEntityAccess.java b/src/main/java/net/minecraft/server/IEntityAccess.java
-index dca18af..43e4c70 100644
+index dca18afdb..43e4c7075 100644
 --- a/src/main/java/net/minecraft/server/IEntityAccess.java
 +++ b/src/main/java/net/minecraft/server/IEntityAccess.java
 @@ -59,6 +59,7 @@ public interface IEntityAccess {
@@ -34,7 +34,7 @@ index dca18af..43e4c70 100644
      default EntityHuman a(double d0, double d1, double d2, double d3, @Nullable Predicate<Entity> predicate) {
          double d4 = -1.0D;
 diff --git a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
-index b05f6c2..62b331c 100644
+index b05f6c2f2..62b331cc1 100644
 --- a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
 +++ b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
 @@ -50,7 +50,28 @@ public abstract class MobSpawnerAbstract {
@@ -68,5 +68,5 @@ index b05f6c2..62b331c 100644
  
      public void c() {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0006-PlayerUseItem-Event.patch
+++ b/patches/server/0006-PlayerUseItem-Event.patch
@@ -1,16 +1,16 @@
-From acc53e3ce806301a03bff46cda44659753314a6b Mon Sep 17 00:00:00 2001
+From 25f44cd468b2dd519744cedb88547b07bda5a7bb Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 22 Dec 2012 00:35:15 -0500
 Subject: [PATCH] PlayerUseItem Event
 
 This lets us control when an item is consumed and change the item.
 ---
- .../java/net/minecraft/server/EntityLiving.java    |  2 +-
- .../minecraft/server/PlayerInteractManager.java    | 89 ++++++++++++++++++----
+ .../net/minecraft/server/EntityLiving.java    |  2 +-
+ .../server/PlayerInteractManager.java         | 89 ++++++++++++++++---
  2 files changed, 77 insertions(+), 14 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 31d14b1..1e8dc4a 100644
+index 31d14b19b..1e8dc4aba 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -1874,7 +1874,7 @@ public abstract class EntityLiving extends Entity {
@@ -23,7 +23,7 @@ index 31d14b1..1e8dc4a 100644
              this.setSlot(EnumItemSlot.MAINHAND, itemstack);
          } else {
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index c96564a..847365e 100644
+index c96564a59..847365e29 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
 @@ -383,6 +383,14 @@ public class PlayerInteractManager {
@@ -163,5 +163,5 @@ index c96564a..847365e 100644
          }
          return enuminteractionresult;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0007-Hidden-Item-Meta.patch
+++ b/patches/server/0007-Hidden-Item-Meta.patch
@@ -1,4 +1,4 @@
-From 81926b75fac98cc91a0904af0f08f7e43b51ed21 Mon Sep 17 00:00:00 2001
+From fd71f28b403d06b07770c08872fc6073d5af9c33 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 27 Feb 2013 23:27:45 -0500
 Subject: [PATCH] Hidden Item Meta
@@ -13,15 +13,15 @@ Then you can store Data on 21+
 Also adds a &&::SHINY tag to send a fake enchantment aura if it does not exists.
 Must be set before META
 ---
- .../com/empireminecraft/api/HiddenItemMeta.java    | 95 ++++++++++++++++++++++
- src/main/java/net/minecraft/server/ItemStack.java  |  2 +-
- .../net/minecraft/server/PacketDataSerializer.java |  2 +
+ .../empireminecraft/api/HiddenItemMeta.java   | 95 +++++++++++++++++++
+ .../java/net/minecraft/server/ItemStack.java  |  2 +-
+ .../server/PacketDataSerializer.java          |  2 +
  3 files changed, 98 insertions(+), 1 deletion(-)
  create mode 100644 src/main/java/com/empireminecraft/api/HiddenItemMeta.java
 
 diff --git a/src/main/java/com/empireminecraft/api/HiddenItemMeta.java b/src/main/java/com/empireminecraft/api/HiddenItemMeta.java
 new file mode 100644
-index 0000000..6708ae1
+index 000000000..6708ae161
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/HiddenItemMeta.java
 @@ -0,0 +1,95 @@
@@ -121,7 +121,7 @@ index 0000000..6708ae1
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index c6600aa..13ac558 100644
+index c6600aa14..13ac55847 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -54,7 +54,7 @@ public final class ItemStack {
@@ -134,7 +134,7 @@ index c6600aa..13ac558 100644
      private EntityItemFrame i;
      private ShapeDetectorBlock j;
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index dac560c..7415d79 100644
+index dac560c63..7415d7990 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
 @@ -256,6 +256,7 @@ public class PacketDataSerializer extends ByteBuf {
@@ -154,5 +154,5 @@ index dac560c..7415d79 100644
                      NBTTagCompound owner = itemstack.tag.getCompound("SkullOwner");
                      String ownerOrig = itemstack.tag.getString("SkullOwnerOrig");
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0008-Persistent-and-Temporary-Meta-API.patch
+++ b/patches/server/0008-Persistent-and-Temporary-Meta-API.patch
@@ -1,34 +1,34 @@
-From 620da6a1986b5c670b0674987269d27336b9dd0d Mon Sep 17 00:00:00 2001
+From b32974684c8bf9b624e15f10b6fbee1c06a6de34 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 4 Mar 2013 23:35:02 -0500
 Subject: [PATCH] Persistent and Temporary Meta API
 
 ---
- .../com/empireminecraft/api/CraftEmpireAPI.java    |   3 +
- .../empireminecraft/api/meta/CraftEAPI_Meta.java   |  80 ++++
- src/main/java/net/minecraft/server/Chunk.java      |   2 +
- .../net/minecraft/server/ChunkRegionLoader.java    |   3 +
- src/main/java/net/minecraft/server/Entity.java     |   3 +
- .../java/net/minecraft/server/MetaApiAccessor.java | 511 +++++++++++++++++++++
- .../minecraft/server/PacketPlayOutMapChunk.java    |   1 +
- .../server/PacketPlayOutTileEntityData.java        |   1 +
- src/main/java/net/minecraft/server/TileEntity.java |   3 +
- src/main/java/net/minecraft/server/World.java      |   1 +
- src/main/java/net/minecraft/server/WorldData.java  |   3 +
- .../java/net/minecraft/server/WorldServer.java     |   2 +-
- .../java/org/bukkit/craftbukkit/CraftChunk.java    |   2 +
- .../java/org/bukkit/craftbukkit/CraftServer.java   |   3 +
- .../craftbukkit/block/CraftBlockEntityState.java   |   7 +
- .../bukkit/craftbukkit/block/CraftBlockState.java  |   7 +
- .../org/bukkit/craftbukkit/entity/CraftEntity.java |   2 +
- .../craftbukkit/event/CraftEventFactory.java       |   5 +
- .../craftbukkit/inventory/CraftInventory.java      |  11 +
+ .../empireminecraft/api/CraftEmpireAPI.java   |   3 +
+ .../api/meta/CraftEAPI_Meta.java              |  80 +++
+ src/main/java/net/minecraft/server/Chunk.java |   2 +
+ .../minecraft/server/ChunkRegionLoader.java   |   3 +
+ .../java/net/minecraft/server/Entity.java     |   3 +
+ .../net/minecraft/server/MetaApiAccessor.java | 511 ++++++++++++++++++
+ .../server/PacketPlayOutMapChunk.java         |   1 +
+ .../server/PacketPlayOutTileEntityData.java   |   1 +
+ .../java/net/minecraft/server/TileEntity.java |   3 +
+ src/main/java/net/minecraft/server/World.java |   1 +
+ .../java/net/minecraft/server/WorldData.java  |   3 +
+ .../net/minecraft/server/WorldServer.java     |   2 +-
+ .../org/bukkit/craftbukkit/CraftChunk.java    |   2 +
+ .../org/bukkit/craftbukkit/CraftServer.java   |   3 +
+ .../block/CraftBlockEntityState.java          |   7 +
+ .../craftbukkit/block/CraftBlockState.java    |   7 +
+ .../craftbukkit/entity/CraftEntity.java       |   2 +
+ .../craftbukkit/event/CraftEventFactory.java  |   5 +
+ .../craftbukkit/inventory/CraftInventory.java |  11 +
  19 files changed, 649 insertions(+), 1 deletion(-)
  create mode 100644 src/main/java/com/empireminecraft/api/meta/CraftEAPI_Meta.java
  create mode 100644 src/main/java/net/minecraft/server/MetaApiAccessor.java
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
-index 7b295bc..f3c9419 100644
+index 7b295bc86..f3c9419c8 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 @@ -23,6 +23,8 @@
@@ -50,7 +50,7 @@ index 7b295bc..f3c9419 100644
  }
 diff --git a/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Meta.java b/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Meta.java
 new file mode 100644
-index 0000000..a9a194b
+index 000000000..a9a194b3a
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Meta.java
 @@ -0,0 +1,80 @@
@@ -135,7 +135,7 @@ index 0000000..a9a194b
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 67dc837..5d50643 100644
+index 67dc837f4..5d506435d 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -139,6 +139,8 @@ public class Chunk implements IChunkAccess {
@@ -148,7 +148,7 @@ index 67dc837..5d50643 100644
      public boolean needsDecoration;
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index a028074..a18c02b 100644
+index a02807411..a18c02b01 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -1,6 +1,7 @@
@@ -176,7 +176,7 @@ index a028074..a18c02b 100644
          nbttagcompound1.setLong("InhabitedTime", ichunkaccess.q());
          nbttagcompound1.setString("Status", ichunkaccess.getChunkStatus().d());
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index e8def7f..2feefd2 100644
+index e8def7f81..2feefd2d9 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -53,6 +53,7 @@ import org.bukkit.plugin.PluginManager;
@@ -205,7 +205,7 @@ index e8def7f..2feefd2 100644
                  origin = new Location(world.getWorld(), originTag.getDoubleAt(0), originTag.getDoubleAt(1), originTag.getDoubleAt(2));
 diff --git a/src/main/java/net/minecraft/server/MetaApiAccessor.java b/src/main/java/net/minecraft/server/MetaApiAccessor.java
 new file mode 100644
-index 0000000..debf613
+index 000000000..debf613e9
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/MetaApiAccessor.java
 @@ -0,0 +1,511 @@
@@ -721,7 +721,7 @@ index 0000000..debf613
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
-index 4833176..7f3d584 100644
+index 483317608..7f3d584af 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 @@ -85,6 +85,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
@@ -733,7 +733,7 @@ index 4833176..7f3d584 100644
                  this.f.add(nbttagcompound);
              }
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutTileEntityData.java b/src/main/java/net/minecraft/server/PacketPlayOutTileEntityData.java
-index 6bcb19b..cc7fffe 100644
+index 6bcb19b56..cc7fffec5 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutTileEntityData.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutTileEntityData.java
 @@ -11,6 +11,7 @@ public class PacketPlayOutTileEntityData implements Packet<PacketListenerPlayOut
@@ -745,7 +745,7 @@ index 6bcb19b..cc7fffe 100644
          this.b = i;
          this.c = nbttagcompound;
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index b8ddb99..c404d1a 100644
+index b8ddb99fa..c404d1a7e 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -79,6 +79,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
@@ -773,7 +773,7 @@ index b8ddb99..c404d1a 100644
      // Paper start
      public InventoryHolder getOwner() {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index b81b374..01a7c30 100644
+index b81b37445..01a7c30d7 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -464,6 +464,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -785,7 +785,7 @@ index b81b374..01a7c30 100644
                  // CraftBukkit start
                  if (!this.captureBlockStates) { // Don't notify clients or update physics while capturing blockstates
 diff --git a/src/main/java/net/minecraft/server/WorldData.java b/src/main/java/net/minecraft/server/WorldData.java
-index ca4c314..d6ee28c 100644
+index ca4c31458..d6ee28c78 100644
 --- a/src/main/java/net/minecraft/server/WorldData.java
 +++ b/src/main/java/net/minecraft/server/WorldData.java
 @@ -73,6 +73,7 @@ public class WorldData {
@@ -813,7 +813,7 @@ index ca4c314..d6ee28c 100644
          if (nbttagcompound1 != null) {
              nbttagcompound.set("Player", nbttagcompound1);
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index ad4e65e..c44ccb4 100644
+index 4497f6a60..eec9a24a3 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -50,7 +50,7 @@ import org.bukkit.event.weather.LightningStrikeEvent;
@@ -826,7 +826,7 @@ index ad4e65e..c44ccb4 100644
      private final Map<UUID, Entity> entitiesByUUID = Maps.newHashMap();
      private final Queue<Entity> entitiesToAdd = Queues.newArrayDeque();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index bb3e480..0bd7420 100644
+index bb3e4805b..0bd7420b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -32,6 +32,8 @@ import org.bukkit.plugin.Plugin;
@@ -839,7 +839,7 @@ index bb3e480..0bd7420 100644
      private final int x;
      private final int z;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b6579ab..8a3b8a9 100644
+index b6579abc3..8a3b8a95d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -855,6 +855,9 @@ public final class CraftServer implements Server {
@@ -853,7 +853,7 @@ index b6579ab..8a3b8a9 100644
          enablePlugins(PluginLoadOrder.STARTUP);
          enablePlugins(PluginLoadOrder.POSTWORLD);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 3e22d55..6334548 100644
+index 3e22d558e..6334548c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 @@ -156,4 +156,11 @@ public class CraftBlockEntityState<T extends TileEntity> extends CraftBlockState
@@ -869,7 +869,7 @@ index 3e22d55..6334548 100644
 +    // EMC end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
-index 0cb5582..3e3f10d 100644
+index 0cb5582b1..3e3f10dc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
 @@ -294,4 +294,11 @@ public class CraftBlockState implements BlockState {
@@ -885,7 +885,7 @@ index 0cb5582..3e3f10d 100644
 +    // EMC end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 1504294..9197755 100644
+index 15042943c..919775527 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -166,6 +166,8 @@ import org.bukkit.util.NumberConversions;
@@ -898,7 +898,7 @@ index 1504294..9197755 100644
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2399656..0597998 100644
+index 2399656a6..059799859 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1333,6 +1333,11 @@ public class CraftEventFactory {
@@ -914,7 +914,7 @@ index 2399656..0597998 100644
  
      public static ItemStack handleEditBookEvent(EntityPlayer player, EnumItemSlot slot, ItemStack itemInHand, ItemStack newBookItem) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
-index 026a0c3..d607acf 100644
+index 026a0c399..d607acf53 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
 @@ -31,6 +31,17 @@ import org.bukkit.inventory.ItemStack;
@@ -936,5 +936,5 @@ index 026a0c3..d607acf 100644
          this.inventory = inventory;
      }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0009-Anvil-Event.patch
+++ b/patches/server/0009-Anvil-Event.patch
@@ -1,15 +1,15 @@
-From e22887024eb7b1958bc91f519d2e5370977dc8c7 Mon Sep 17 00:00:00 2001
+From 13896740875ad4482bdd98d7e439726891ed54d5 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 31 Dec 2012 01:25:46 -0500
 Subject: [PATCH] Anvil Event
 
 Fire an event for anvil usage, remove cap from server, send level to client
 ---
- src/main/java/net/minecraft/server/ContainerAnvil.java | 14 ++++++++++++++
+ .../java/net/minecraft/server/ContainerAnvil.java  | 14 ++++++++++++++
  1 file changed, 14 insertions(+)
 
 diff --git a/src/main/java/net/minecraft/server/ContainerAnvil.java b/src/main/java/net/minecraft/server/ContainerAnvil.java
-index 7718c5a..e2a9ca7 100644
+index 7718c5a3b..e2a9ca785 100644
 --- a/src/main/java/net/minecraft/server/ContainerAnvil.java
 +++ b/src/main/java/net/minecraft/server/ContainerAnvil.java
 @@ -7,6 +7,10 @@ import org.apache.logging.log4j.LogManager;
@@ -41,5 +41,5 @@ index 7718c5a..e2a9ca7 100644
              if (!itemstack1.isEmpty()) {
                  int k2 = itemstack1.getRepairCost();
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0011-EntityTasks-API.patch
+++ b/patches/server/0011-EntityTasks-API.patch
@@ -1,4 +1,4 @@
-From a9561885ff58f03a1260b658a999e052f0248131 Mon Sep 17 00:00:00 2001
+From 1271e2eb35e5947ae23361c0c7a1755504f47780 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 11 Jun 2013 23:15:00 -0400
 Subject: [PATCH] EntityTasks API
@@ -6,16 +6,16 @@ Subject: [PATCH] EntityTasks API
 Allows scheduling repeating task timers on an entity level.
 Avoids Bukkit system so that tasks will simply maintain themselves on entity removal.
 ---
- .../com/empireminecraft/api/CraftEAPI_Entity.java  | 15 ++++++++
- src/main/java/net/minecraft/server/Entity.java     |  1 +
- .../net/minecraft/server/EntityTasksHandler.java   | 42 ++++++++++++++++++++++
- .../java/net/minecraft/server/WorldServer.java     |  2 ++
- .../java/org/bukkit/craftbukkit/CraftServer.java   |  1 +
+ .../empireminecraft/api/CraftEAPI_Entity.java | 15 +++++++
+ .../java/net/minecraft/server/Entity.java     |  1 +
+ .../minecraft/server/EntityTasksHandler.java  | 42 +++++++++++++++++++
+ .../net/minecraft/server/WorldServer.java     |  2 +
+ .../org/bukkit/craftbukkit/CraftServer.java   |  1 +
  5 files changed, 61 insertions(+)
  create mode 100644 src/main/java/net/minecraft/server/EntityTasksHandler.java
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
-index e7bb900..bb6e529 100644
+index e7bb9003d..bb6e5296a 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 @@ -23,5 +23,20 @@
@@ -40,7 +40,7 @@ index e7bb900..bb6e529 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 2feefd2..aface5b 100644
+index 2feefd2d9..aface5b35 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -54,6 +54,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -53,7 +53,7 @@ index 2feefd2..aface5b 100644
      public static Random SHARED_RANDOM = new Random() {
 diff --git a/src/main/java/net/minecraft/server/EntityTasksHandler.java b/src/main/java/net/minecraft/server/EntityTasksHandler.java
 new file mode 100644
-index 0000000..1cfc10c
+index 000000000..1cfc10c40
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/EntityTasksHandler.java
 @@ -0,0 +1,42 @@
@@ -100,7 +100,7 @@ index 0000000..1cfc10c
 +    public static class TaskList extends ArrayList<EntityTask> {}
 +}
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index c44ccb4..f885d96 100644
+index eec9a24a3..01efe4356 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -565,6 +565,7 @@ public class WorldServer extends World {
@@ -120,7 +120,7 @@ index c44ccb4..f885d96 100644
                      return IRegistry.ENTITY_TYPE.getKey(entity.getEntityType()).toString();
                  });
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8a3b8a9..a760f5e 100644
+index 8a3b8a95d..a760f5ea8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -857,6 +857,7 @@ public final class CraftServer implements Server {
@@ -132,5 +132,5 @@ index 8a3b8a9..a760f5e 100644
          loadPlugins();
          enablePlugins(PluginLoadOrder.STARTUP);
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0012-Attributes-API.patch
+++ b/patches/server/0012-Attributes-API.patch
@@ -1,24 +1,24 @@
-From 83f3c45def20dd3c4420f6db93b27a6d2c833f6e Mon Sep 17 00:00:00 2001
+From 4a9799666f0533c4721b404c3c16e307cf739930 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 6 Dec 2016 22:19:45 -0500
 Subject: [PATCH] Attributes API
 
 ---
- .../com/empireminecraft/api/CraftEmpireAPI.java    |   2 +
- .../api/meta/CraftEAPI_Attributes.java             | 136 +++++++++++++++++++++
- .../net/minecraft/server/AttributeInstance.java    |   2 +-
- .../net/minecraft/server/AttributeMapBase.java     |   4 +-
- .../net/minecraft/server/AttributesAccessor.java   |  48 ++++++++
- .../net/minecraft/server/EntityInsentient.java     |   1 +
- .../java/net/minecraft/server/EntityLiving.java    |   1 +
- .../net/minecraft/server/GenericAttributes.java    |   1 +
- .../net/minecraft/server/PathfinderGoalTarget.java |   2 +-
+ .../empireminecraft/api/CraftEmpireAPI.java   |   2 +
+ .../api/meta/CraftEAPI_Attributes.java        | 136 ++++++++++++++++++
+ .../minecraft/server/AttributeInstance.java   |   2 +-
+ .../minecraft/server/AttributeMapBase.java    |   4 +-
+ .../minecraft/server/AttributesAccessor.java  |  48 +++++++
+ .../minecraft/server/EntityInsentient.java    |   1 +
+ .../net/minecraft/server/EntityLiving.java    |   1 +
+ .../minecraft/server/GenericAttributes.java   |   1 +
+ .../server/PathfinderGoalTarget.java          |   2 +-
  9 files changed, 193 insertions(+), 4 deletions(-)
  create mode 100644 src/main/java/com/empireminecraft/api/meta/CraftEAPI_Attributes.java
  create mode 100644 src/main/java/net/minecraft/server/AttributesAccessor.java
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
-index f3c9419..9b0eb03 100644
+index f3c9419c8..9b0eb03de 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 @@ -23,6 +23,7 @@
@@ -39,7 +39,7 @@ index f3c9419..9b0eb03 100644
  }
 diff --git a/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Attributes.java b/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Attributes.java
 new file mode 100644
-index 0000000..00abcfe
+index 000000000..00abcfe2b
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Attributes.java
 @@ -0,0 +1,136 @@
@@ -180,7 +180,7 @@ index 0000000..00abcfe
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/AttributeInstance.java b/src/main/java/net/minecraft/server/AttributeInstance.java
-index c2430df..8306a16 100644
+index c2430df04..8306a16ad 100644
 --- a/src/main/java/net/minecraft/server/AttributeInstance.java
 +++ b/src/main/java/net/minecraft/server/AttributeInstance.java
 @@ -16,7 +16,7 @@ public interface AttributeInstance {
@@ -193,7 +193,7 @@ index c2430df..8306a16 100644
      @Nullable
      AttributeModifier a(UUID uuid);
 diff --git a/src/main/java/net/minecraft/server/AttributeMapBase.java b/src/main/java/net/minecraft/server/AttributeMapBase.java
-index 9617be9..f0bf0b8 100644
+index 9617be965..f0bf0b842 100644
 --- a/src/main/java/net/minecraft/server/AttributeMapBase.java
 +++ b/src/main/java/net/minecraft/server/AttributeMapBase.java
 @@ -27,8 +27,8 @@ public abstract class AttributeMapBase {
@@ -209,7 +209,7 @@ index 9617be9..f0bf0b8 100644
              AttributeInstance attributeinstance = this.c(iattribute);
 diff --git a/src/main/java/net/minecraft/server/AttributesAccessor.java b/src/main/java/net/minecraft/server/AttributesAccessor.java
 new file mode 100644
-index 0000000..9d4f099
+index 000000000..9d4f099ff
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/AttributesAccessor.java
 @@ -0,0 +1,48 @@
@@ -262,7 +262,7 @@ index 0000000..9d4f099
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index d00e99c..47bdfee 100644
+index d00e99cdb..47bdfeec7 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -978,6 +978,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -274,7 +274,7 @@ index d00e99c..47bdfee 100644
              this.p(true);
          } else {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 1e8dc4a..70664dd 100644
+index 1e8dc4aba..70664dd79 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -197,6 +197,7 @@ public abstract class EntityLiving extends Entity {
@@ -286,7 +286,7 @@ index 1e8dc4a..70664dd 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/GenericAttributes.java b/src/main/java/net/minecraft/server/GenericAttributes.java
-index 469e293..059d62c 100644
+index 469e293c2..059d62c6b 100644
 --- a/src/main/java/net/minecraft/server/GenericAttributes.java
 +++ b/src/main/java/net/minecraft/server/GenericAttributes.java
 @@ -63,6 +63,7 @@ public class GenericAttributes {
@@ -298,7 +298,7 @@ index 469e293..059d62c 100644
          NBTTagCompound nbttagcompound = new NBTTagCompound();
  
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalTarget.java b/src/main/java/net/minecraft/server/PathfinderGoalTarget.java
-index f15d8bf..28b20f9 100644
+index f15d8bf83..28b20f9c5 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalTarget.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalTarget.java
 @@ -69,7 +69,7 @@ public abstract class PathfinderGoalTarget extends PathfinderGoal {
@@ -311,5 +311,5 @@ index f15d8bf..28b20f9 100644
          return attributeinstance == null ? 16.0D : attributeinstance.getValue();
      }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0013-Entity-AI-API.patch
+++ b/patches/server/0013-Entity-AI-API.patch
@@ -1,40 +1,40 @@
-From 56d03faf7a1c83351e4db3ddbe981b42c0e568b3 Mon Sep 17 00:00:00 2001
+From 5b9e3ece311bde95993ddfd36cef6d2cd6acbd2d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 6 Dec 2016 22:22:14 -0500
 Subject: [PATCH] Entity AI API
 
 ---
- .../com/empireminecraft/api/CraftEAPI_Entity.java  | 135 ++++++++++
- .../java/com/empireminecraft/api/EntityAIApi.java  | 297 +++++++++++++++++++++
- .../net/minecraft/server/AttributesAccessor.java   |   1 +
- src/main/java/net/minecraft/server/Entity.java     |  18 +-
- .../java/net/minecraft/server/EntityAnimal.java    |   2 +-
- .../java/net/minecraft/server/EntityBlaze.java     |  27 +-
- .../java/net/minecraft/server/EntityCreature.java  |   1 +
- .../net/minecraft/server/EntityEnderSignal.java    |  22 +-
- .../java/net/minecraft/server/EntityGhast.java     |   3 +-
- .../net/minecraft/server/EntityGoalAccessor.java   |  20 ++
- src/main/java/net/minecraft/server/EntityItem.java |   3 +-
- .../java/net/minecraft/server/EntityLiving.java    |  13 +-
- .../java/net/minecraft/server/EntitySpider.java    |   4 +
- src/main/java/net/minecraft/server/EntityWolf.java |   2 +
- .../server/PathfinderGoalArrowAttack.java          |   8 +-
- .../minecraft/server/PathfinderGoalBowShoot.java   |   4 +-
- .../minecraft/server/PathfinderGoalFleeSun.java    |   4 +-
- .../net/minecraft/server/PathfinderGoalPanic.java  |   3 +-
- .../minecraft/server/PathfinderGoalSelector.java   |   6 +-
- .../minecraft/server/PathfinderGoalWrapped.java    |   2 +-
- .../java/net/minecraft/server/WorldServer.java     |   3 +-
- .../org/bukkit/craftbukkit/entity/CraftBlaze.java  |  18 ++
- .../craftbukkit/entity/CraftEnderSignal.java       |   3 +-
- .../org/bukkit/craftbukkit/entity/CraftGhast.java  |   9 +
- src/main/java/org/spigotmc/ActivationRange.java    |   1 +
+ .../empireminecraft/api/CraftEAPI_Entity.java | 135 ++++++++
+ .../com/empireminecraft/api/EntityAIApi.java  | 297 ++++++++++++++++++
+ .../minecraft/server/AttributesAccessor.java  |   1 +
+ .../java/net/minecraft/server/Entity.java     |  18 +-
+ .../net/minecraft/server/EntityAnimal.java    |   2 +-
+ .../net/minecraft/server/EntityBlaze.java     |  27 +-
+ .../net/minecraft/server/EntityCreature.java  |   1 +
+ .../minecraft/server/EntityEnderSignal.java   |  22 +-
+ .../net/minecraft/server/EntityGhast.java     |   3 +-
+ .../minecraft/server/EntityGoalAccessor.java  |  20 ++
+ .../java/net/minecraft/server/EntityItem.java |   3 +-
+ .../net/minecraft/server/EntityLiving.java    |  13 +-
+ .../net/minecraft/server/EntitySpider.java    |   4 +
+ .../java/net/minecraft/server/EntityWolf.java |   2 +
+ .../server/PathfinderGoalArrowAttack.java     |   8 +-
+ .../server/PathfinderGoalBowShoot.java        |   4 +-
+ .../server/PathfinderGoalFleeSun.java         |   4 +-
+ .../minecraft/server/PathfinderGoalPanic.java |   3 +-
+ .../server/PathfinderGoalSelector.java        |   6 +-
+ .../server/PathfinderGoalWrapped.java         |   2 +-
+ .../net/minecraft/server/WorldServer.java     |   3 +-
+ .../bukkit/craftbukkit/entity/CraftBlaze.java |  18 ++
+ .../craftbukkit/entity/CraftEnderSignal.java  |   3 +-
+ .../bukkit/craftbukkit/entity/CraftGhast.java |   9 +
+ .../java/org/spigotmc/ActivationRange.java    |   1 +
  25 files changed, 580 insertions(+), 29 deletions(-)
  create mode 100644 src/main/java/com/empireminecraft/api/EntityAIApi.java
  create mode 100644 src/main/java/net/minecraft/server/EntityGoalAccessor.java
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
-index bb6e529..7c5cd34 100644
+index bb6e5296a..7c5cd3454 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 @@ -23,9 +23,21 @@
@@ -189,7 +189,7 @@ index bb6e529..7c5cd34 100644
  }
 diff --git a/src/main/java/com/empireminecraft/api/EntityAIApi.java b/src/main/java/com/empireminecraft/api/EntityAIApi.java
 new file mode 100644
-index 0000000..b28e1eb
+index 000000000..b28e1eb0f
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/EntityAIApi.java
 @@ -0,0 +1,297 @@
@@ -491,7 +491,7 @@ index 0000000..b28e1eb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/AttributesAccessor.java b/src/main/java/net/minecraft/server/AttributesAccessor.java
-index 9d4f099..83a85a8 100644
+index 9d4f099ff..83a85a8d2 100644
 --- a/src/main/java/net/minecraft/server/AttributesAccessor.java
 +++ b/src/main/java/net/minecraft/server/AttributesAccessor.java
 @@ -38,6 +38,7 @@ public final class AttributesAccessor {
@@ -503,7 +503,7 @@ index 9d4f099..83a85a8 100644
              map.registerAttribute(targetRange);
              if (entity instanceof Wither) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index aface5b..d5e14e9 100644
+index aface5b35..d5e14e912 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -148,6 +148,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -616,7 +616,7 @@ index aface5b..d5e14e9 100644
          if (entity instanceof EntityLiving) {
              EnchantmentManager.a((EntityLiving) entity, (Entity) entityliving);
 diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
-index 3e627ea..eabe609 100644
+index 3e627ea08..eabe6092e 100644
 --- a/src/main/java/net/minecraft/server/EntityAnimal.java
 +++ b/src/main/java/net/minecraft/server/EntityAnimal.java
 @@ -6,7 +6,7 @@ import javax.annotation.Nullable;
@@ -629,7 +629,7 @@ index 3e627ea..eabe609 100644
      public ItemStack breedItem; // CraftBukkit - Add breedItem variable
  
 diff --git a/src/main/java/net/minecraft/server/EntityBlaze.java b/src/main/java/net/minecraft/server/EntityBlaze.java
-index 89f1bfa..473af6a 100644
+index 89f1bfa41..473af6a37 100644
 --- a/src/main/java/net/minecraft/server/EntityBlaze.java
 +++ b/src/main/java/net/minecraft/server/EntityBlaze.java
 @@ -8,6 +8,25 @@ public class EntityBlaze extends EntityMonster {
@@ -689,7 +689,7 @@ index 89f1bfa..473af6a 100644
                          }
                      }
 diff --git a/src/main/java/net/minecraft/server/EntityCreature.java b/src/main/java/net/minecraft/server/EntityCreature.java
-index 7dacaa2..f2bc00e 100644
+index 7dacaa216..f2bc00eda 100644
 --- a/src/main/java/net/minecraft/server/EntityCreature.java
 +++ b/src/main/java/net/minecraft/server/EntityCreature.java
 @@ -8,6 +8,7 @@ public abstract class EntityCreature extends EntityInsentient {
@@ -701,7 +701,7 @@ index 7dacaa2..f2bc00e 100644
          super(entitytypes, world);
      }
 diff --git a/src/main/java/net/minecraft/server/EntityEnderSignal.java b/src/main/java/net/minecraft/server/EntityEnderSignal.java
-index ef157ad..711dd1c 100644
+index ef157ad18..711dd1c51 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderSignal.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderSignal.java
 @@ -9,6 +9,18 @@ public class EntityEnderSignal extends Entity {
@@ -770,7 +770,7 @@ index ef157ad..711dd1c 100644
                  this.die();
                  if (this.shouldDropItem) {
 diff --git a/src/main/java/net/minecraft/server/EntityGhast.java b/src/main/java/net/minecraft/server/EntityGhast.java
-index f25c828..7fa4e61 100644
+index f25c828df..7fa4e6113 100644
 --- a/src/main/java/net/minecraft/server/EntityGhast.java
 +++ b/src/main/java/net/minecraft/server/EntityGhast.java
 @@ -7,6 +7,7 @@ public class EntityGhast extends EntityFlying implements IMonster {
@@ -792,7 +792,7 @@ index f25c828..7fa4e61 100644
                  --this.a;
 diff --git a/src/main/java/net/minecraft/server/EntityGoalAccessor.java b/src/main/java/net/minecraft/server/EntityGoalAccessor.java
 new file mode 100644
-index 0000000..d0ee7f3
+index 000000000..d0ee7f304
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/EntityGoalAccessor.java
 @@ -0,0 +1,20 @@
@@ -817,7 +817,7 @@ index 0000000..d0ee7f3
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 97e3790..862d838 100644
+index 97e379090..862d83871 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
 @@ -15,6 +15,7 @@ public class EntityItem extends Entity {
@@ -838,7 +838,7 @@ index 97e3790..862d838 100644
                  if (org.bukkit.craftbukkit.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
                      this.age = 0;
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 70664dd..e3c3abc 100644
+index 70664dd79..e3c3abc58 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -457,6 +457,7 @@ public abstract class EntityLiving extends Entity {
@@ -869,7 +869,7 @@ index 70664dd..e3c3abc 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntitySpider.java b/src/main/java/net/minecraft/server/EntitySpider.java
-index 3929c86..0dc6688 100644
+index 3929c86f8..0dc66887b 100644
 --- a/src/main/java/net/minecraft/server/EntitySpider.java
 +++ b/src/main/java/net/minecraft/server/EntitySpider.java
 @@ -152,6 +152,8 @@ public class EntitySpider extends EntityMonster {
@@ -898,7 +898,7 @@ index 3929c86..0dc6688 100644
              if (f >= 0.5F && this.a.getRandom().nextInt(100) == 0) {
                  this.a.setGoalTarget((EntityLiving) null);
 diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
-index 0249266..9e426c9 100644
+index 02492663a..9e426c9bc 100644
 --- a/src/main/java/net/minecraft/server/EntityWolf.java
 +++ b/src/main/java/net/minecraft/server/EntityWolf.java
 @@ -30,6 +30,7 @@ public class EntityWolf extends EntityTameableAnimal {
@@ -918,7 +918,7 @@ index 0249266..9e426c9 100644
          if (flag) {
              this.datawatcher.set(EntityWolf.bz, (byte) (b0 | 2));
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java b/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java
-index 08aea99..8cbf77e 100644
+index 08aea9969..8cbf77eeb 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java
 @@ -10,10 +10,10 @@ public class PathfinderGoalArrowAttack extends PathfinderGoal {
@@ -937,7 +937,7 @@ index 08aea99..8cbf77e 100644
      public PathfinderGoalArrowAttack(IRangedEntity irangedentity, double d0, int i, float f) {
          this(irangedentity, d0, i, i, f);
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java b/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java
-index 5bdc4b4..fd544c2 100644
+index 5bdc4b4b6..fd544c29a 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java
 @@ -6,8 +6,8 @@ public class PathfinderGoalBowShoot<T extends EntityMonster & IRangedEntity> ext
@@ -952,7 +952,7 @@ index 5bdc4b4..fd544c2 100644
      private int f;
      private boolean g;
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalFleeSun.java b/src/main/java/net/minecraft/server/PathfinderGoalFleeSun.java
-index b18f7c5..41e5f72 100644
+index b18f7c516..41e5f7211 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalFleeSun.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalFleeSun.java
 @@ -6,7 +6,7 @@ import javax.annotation.Nullable;
@@ -974,7 +974,7 @@ index b18f7c5..41e5f72 100644
  
      protected boolean g() {
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalPanic.java b/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
-index f399683..5af2d04 100644
+index f399683b7..5af2d0493 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
 @@ -5,7 +5,7 @@ import javax.annotation.Nullable;
@@ -995,7 +995,7 @@ index f399683..5af2d04 100644
              return false;
          } else {
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalSelector.java b/src/main/java/net/minecraft/server/PathfinderGoalSelector.java
-index 44bb18c..71fa6bb 100644
+index 44bb18c59..71fa6bba5 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalSelector.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalSelector.java
 @@ -23,8 +23,8 @@ public class PathfinderGoalSelector {
@@ -1019,7 +1019,7 @@ index 44bb18c..71fa6bb 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalWrapped.java b/src/main/java/net/minecraft/server/PathfinderGoalWrapped.java
-index 182cd7e..1f7d4e2 100644
+index 182cd7e91..1f7d4e291 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalWrapped.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalWrapped.java
 @@ -5,7 +5,7 @@ import javax.annotation.Nullable;
@@ -1032,7 +1032,7 @@ index 182cd7e..1f7d4e2 100644
      private boolean c;
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 01efe43..cf3c7cc 100644
+index 01efe4356..cf3c7cc69 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -577,7 +577,7 @@ public class WorldServer extends World {
@@ -1053,7 +1053,7 @@ index 01efe43..cf3c7cc 100644
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBlaze.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBlaze.java
-index 089419e..bf7eee9 100644
+index 089419ede..bf7eee91a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBlaze.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBlaze.java
 @@ -24,4 +24,22 @@ public class CraftBlaze extends CraftMonster implements Blaze {
@@ -1080,7 +1080,7 @@ index 089419e..bf7eee9 100644
 +    // EMC end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderSignal.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderSignal.java
-index d771fdc..33a67f1 100644
+index d771fdc6e..33a67f12a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderSignal.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderSignal.java
 @@ -34,8 +34,9 @@ public class CraftEnderSignal extends CraftEntity implements EnderSignal {
@@ -1095,7 +1095,7 @@ index d771fdc..33a67f1 100644
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
-index cac82ce..913f4a1 100644
+index cac82ce76..913f4a11a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
 @@ -25,4 +25,13 @@ public class CraftGhast extends CraftFlying implements Ghast {
@@ -1113,7 +1113,7 @@ index cac82ce..913f4a1 100644
 +    // EMC end
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 92601c5..5da3520 100644
+index 92601c581..5da3520f2 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -248,6 +248,7 @@ public class ActivationRange
@@ -1125,5 +1125,5 @@ index 92601c5..5da3520 100644
          if ( !entity.inChunk || entity instanceof EntityFireworks ) {
              return true;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0014-Entity-Serialization.patch
+++ b/patches/server/0014-Entity-Serialization.patch
@@ -1,17 +1,17 @@
-From d9be012bf304ceb981ae82b74df96c56fac0d52c Mon Sep 17 00:00:00 2001
+From 14a397d00c445f5deed32041848aaa8a3c3c4f2c Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 12 Jul 2013 18:58:19 -0400
 Subject: [PATCH] Entity Serialization
 
 Allow serializing an Entity to raw NBT, and to get an Entity object without spawning it into the world.
 ---
- .../com/empireminecraft/api/CraftEAPI_Entity.java  | 60 ++++++++++++++++++++++
- src/main/java/net/minecraft/server/Entity.java     |  1 +
- .../org/bukkit/craftbukkit/entity/CraftEntity.java | 10 ++++
+ .../empireminecraft/api/CraftEAPI_Entity.java | 60 +++++++++++++++++++
+ .../java/net/minecraft/server/Entity.java     |  1 +
+ .../craftbukkit/entity/CraftEntity.java       | 10 ++++
  3 files changed, 71 insertions(+)
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
-index 7c5cd34..127ae66 100644
+index 7c5cd3454..127ae661c 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEAPI_Entity.java
 @@ -24,10 +24,17 @@
@@ -98,7 +98,7 @@ index 7c5cd34..127ae66 100644
 +
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d5e14e9..26009cd 100644
+index d5e14e912..26009cd8d 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1552,6 +1552,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -110,7 +110,7 @@ index d5e14e9..26009cd 100644
          return this.isPassenger() ? false : this.c(nbttagcompound);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 9197755..f1299c6 100644
+index 919775527..f1299c6ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -176,6 +176,16 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -131,5 +131,5 @@ index 9197755..f1299c6 100644
          this.server = server;
          this.entity = entity;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0015-MonsterEggSpawn-Event.patch
+++ b/patches/server/0015-MonsterEggSpawn-Event.patch
@@ -1,15 +1,15 @@
-From ba8cf1a92ade5e4aa32a21784c5b603a312155f6 Mon Sep 17 00:00:00 2001
+From a6e82bda0d5de216c8b850f9bfbb50b97b972439 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 20 Jul 2013 22:40:56 -0400
 Subject: [PATCH] MonsterEggSpawn Event
 
 Get the itemstack used to spawn an entity
 ---
- .../java/net/minecraft/server/EntityTypes.java     | 29 +++++++++++++++++++---
+ .../net/minecraft/server/EntityTypes.java     | 29 +++++++++++++++++--
  1 file changed, 26 insertions(+), 3 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index a7fc34f..18be8b5 100644
+index a7fc34f85..18be8b510 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -11,6 +11,7 @@ import java.util.stream.Stream;
@@ -37,11 +37,11 @@ index a7fc34f..18be8b5 100644
 +        return this.spawnCreature(world, itemstack, nbttagcompound, ichatbasecomponent, entityhuman, blockposition, enummobspawn, flag, flag1, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER_EGG);
      }
  
-     @Nullable
++    @Nullable
 +    public T spawnCreature(World world, @Nullable NBTTagCompound nbttagcompound, @Nullable IChatBaseComponent ichatbasecomponent, @Nullable EntityHuman entityhuman, BlockPosition blockposition, EnumMobSpawn enummobspawn, boolean flag, boolean flag1) {
 +        return spawnCreature(world, null, nbttagcompound, ichatbasecomponent, entityhuman, blockposition, enummobspawn, flag, flag1, CreatureSpawnEvent.SpawnReason.NATURAL);
 +    }
-+    @Nullable
+     @Nullable
      public T spawnCreature(World world, @Nullable NBTTagCompound nbttagcompound, @Nullable IChatBaseComponent ichatbasecomponent, @Nullable EntityHuman entityhuman, BlockPosition blockposition, EnumMobSpawn enummobspawn, boolean flag, boolean flag1, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason) {
 +        return spawnCreature(world, null, nbttagcompound, ichatbasecomponent, entityhuman, blockposition, enummobspawn, flag, flag1, spawnReason);
 +    }
@@ -65,5 +65,5 @@ index a7fc34f..18be8b5 100644
          return world.addEntity(t0, spawnReason) ? t0 : null; // Don't return an entity when CreatureSpawnEvent is canceled
          // CraftBukkit end
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0016-Allow-force-spawns.patch
+++ b/patches/server/0016-Allow-force-spawns.patch
@@ -1,4 +1,4 @@
-From 5a84dd654861be9a6c403c398124c1e50918697c Mon Sep 17 00:00:00 2001
+From 101100d59dcd573fc0efbb06a1b8758cb737cc3d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 26 Jul 2013 22:19:29 -0400
 Subject: [PATCH] Allow force spawns
@@ -6,12 +6,12 @@ Subject: [PATCH] Allow force spawns
 Pass spawn reason force to not allow plugins to block
 Force some cases where plugins should not be allowed to block it.
 ---
- src/main/java/net/minecraft/server/WorldServer.java               | 4 ++--
- src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java | 2 +-
+ src/main/java/net/minecraft/server/WorldServer.java           | 4 ++--
+ .../java/org/bukkit/craftbukkit/event/CraftEventFactory.java  | 2 +-
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index cf3c7cc..bf9f521 100644
+index cf3c7cc69..bf9f52126 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -943,7 +943,7 @@ public class WorldServer extends World {
@@ -33,7 +33,7 @@ index cf3c7cc..bf9f521 100644
              } else {
                  ichunkaccess.a(entity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0597998..6751277 100644
+index 059799859..675127700 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -578,7 +578,7 @@ public class CraftEventFactory {
@@ -46,5 +46,5 @@ index 0597998..6751277 100644
              if (vehicle != null) {
                  vehicle.dead = true;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0018-Better-hopper-events.patch
+++ b/patches/server/0018-Better-hopper-events.patch
@@ -1,17 +1,17 @@
-From 81543cfd986a8be907d7ae45eb346c529cb3572b Mon Sep 17 00:00:00 2001
+From 9894d61ee6878d0e3f6d589c6d63b4f3919bdbc3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 9 Sep 2013 19:41:07 -0400
 Subject: [PATCH] Better hopper events
 
 ---
- .../java/com/empireminecraft/api/HopperEvents.java | 32 ++++++++++++++++++++++
- .../net/minecraft/server/TileEntityHopper.java     |  7 ++++-
+ .../com/empireminecraft/api/HopperEvents.java | 32 +++++++++++++++++++
+ .../minecraft/server/TileEntityHopper.java    |  7 +++-
  2 files changed, 38 insertions(+), 1 deletion(-)
  create mode 100644 src/main/java/com/empireminecraft/api/HopperEvents.java
 
 diff --git a/src/main/java/com/empireminecraft/api/HopperEvents.java b/src/main/java/com/empireminecraft/api/HopperEvents.java
 new file mode 100644
-index 0000000..0697d6c
+index 000000000..0697d6ce6
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/HopperEvents.java
 @@ -0,0 +1,32 @@
@@ -48,7 +48,7 @@ index 0000000..0697d6c
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index 6f6519f..83abde9 100644
+index 6f6519f6c..83abde9c8 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
 @@ -345,6 +345,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
@@ -73,5 +73,5 @@ index 6f6519f..83abde9 100644
                  return a(ihopper, iinventory, i, enumdirection);
              });
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0020-AchievementBroadcastEvent.patch
+++ b/patches/server/0020-AchievementBroadcastEvent.patch
@@ -1,15 +1,15 @@
-From 4afab6d22516a2ab09885bd48d9e0faafa609fb9 Mon Sep 17 00:00:00 2001
+From b753abfc3dab8c098b0eddb3688138d60af9c11b Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 6 Dec 2013 20:54:23 -0500
 Subject: [PATCH] AchievementBroadcastEvent
 
 Used to control who sees achievement message
 ---
- .../java/net/minecraft/server/AdvancementDataPlayer.java     | 12 +++++++++++-
+ .../net/minecraft/server/AdvancementDataPlayer.java  | 12 +++++++++++-
  1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
-index b7f1f39..e7071e0 100644
+index b7f1f39a1..e7071e0ea 100644
 --- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
 +++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
 @@ -31,6 +31,8 @@ import java.util.stream.Stream;
@@ -39,5 +39,5 @@ index b7f1f39..e7071e0 100644
              }
          }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0025-Chat-API.patch
+++ b/patches/server/0025-Chat-API.patch
@@ -1,4 +1,4 @@
-From 70a6b696e6b0529775e0c66ae10e1d2f48ebac64 Mon Sep 17 00:00:00 2001
+From 4605002e5eaf533955370d3a0e60f177e3d6807f Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 17 Feb 2014 00:05:26 -0500
 Subject: [PATCH] Chat API
@@ -6,15 +6,15 @@ Subject: [PATCH] Chat API
 Initial for Fanciful Credits to http://forums.bukkit.org/threads/lib-fanciful-pleasant-chat-message-formatting.195148/
 But did a lot of bug fixing and improving upon it, and designing into the Empire API
 ---
- .../com/empireminecraft/api/CraftEmpireAPI.java    |   2 +
- .../empireminecraft/api/FancifulChatAPIImpl.java   | 267 +++++++++++++++++++++
- .../empireminecraft/api/meta/CraftEAPI_Chat.java   |  40 +++
+ .../empireminecraft/api/CraftEmpireAPI.java   |   2 +
+ .../api/FancifulChatAPIImpl.java              | 267 ++++++++++++++++++
+ .../api/meta/CraftEAPI_Chat.java              |  40 +++
  3 files changed, 309 insertions(+)
  create mode 100644 src/main/java/com/empireminecraft/api/FancifulChatAPIImpl.java
  create mode 100644 src/main/java/com/empireminecraft/api/meta/CraftEAPI_Chat.java
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
-index 9b0eb03..a6e2c3d 100644
+index 9b0eb03de..a6e2c3d28 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEmpireAPI.java
 @@ -24,6 +24,7 @@
@@ -35,7 +35,7 @@ index 9b0eb03..a6e2c3d 100644
  }
 diff --git a/src/main/java/com/empireminecraft/api/FancifulChatAPIImpl.java b/src/main/java/com/empireminecraft/api/FancifulChatAPIImpl.java
 new file mode 100644
-index 0000000..7e2d2f2
+index 000000000..7e2d2f28f
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/FancifulChatAPIImpl.java
 @@ -0,0 +1,267 @@
@@ -308,7 +308,7 @@ index 0000000..7e2d2f2
 +
 diff --git a/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Chat.java b/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Chat.java
 new file mode 100644
-index 0000000..33b49b3
+index 000000000..33b49b3d9
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/meta/CraftEAPI_Chat.java
 @@ -0,0 +1,40 @@
@@ -353,5 +353,5 @@ index 0000000..33b49b3
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0027-Fire-EntityTargetLivingEntityEvent-for-GoalNearestAt.patch
+++ b/patches/server/0027-Fire-EntityTargetLivingEntityEvent-for-GoalNearestAt.patch
@@ -1,4 +1,4 @@
-From 109fc85d27e80ebaf14ad85c584dd995af8b74e3 Mon Sep 17 00:00:00 2001
+From dd8644a46e63460a00c8c5a8ba87011a32164659 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 28 Feb 2014 22:25:04 -0500
 Subject: [PATCH] Fire EntityTargetLivingEntityEvent for
@@ -6,11 +6,11 @@ Subject: [PATCH] Fire EntityTargetLivingEntityEvent for
 
 If cancelled, move to next in list
 ---
- .../server/PathfinderGoalNearestAttackableTarget.java     | 15 ++++++++++++++-
+ .../PathfinderGoalNearestAttackableTarget.java    | 15 ++++++++++++++-
  1 file changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java b/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java
-index 3295dfa..7c7a841 100644
+index 3295dfa98..7c7a841f0 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java
 @@ -1,5 +1,7 @@
@@ -42,5 +42,5 @@ index 3295dfa..7c7a841 100644
              this.c = this.e.world.a(this.d, this.e, this.e.locX, this.e.locY + (double) this.e.getHeadHeight(), this.e.locZ);
          }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0028-Disable-UUID-conversion-Already-done.patch
+++ b/patches/server/0028-Disable-UUID-conversion-Already-done.patch
@@ -1,15 +1,15 @@
-From f7c51fa9a0a18a67d446f9d60a3e8b86284dbdb2 Mon Sep 17 00:00:00 2001
+From 5902f3f0f5312da7a61c4f480341d068180b88c2 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 14 Apr 2014 20:44:38 -0400
 Subject: [PATCH] Disable UUID conversion - Already done
 
 ---
- src/main/java/net/minecraft/server/DedicatedServer.java              | 2 +-
- src/main/java/net/minecraft/server/NameReferencingFileConverter.java | 1 +
+ src/main/java/net/minecraft/server/DedicatedServer.java         | 2 +-
+ .../java/net/minecraft/server/NameReferencingFileConverter.java | 1 +
  2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 5bc19cd..283cd3e 100644
+index 5bc19cd08..283cd3e5f 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -241,7 +241,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -22,7 +22,7 @@ index 5bc19cd..283cd3e 100644
          }
  
 diff --git a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
-index 0794aff..2cca728 100644
+index 0794aff5b..2cca7280f 100644
 --- a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
 +++ b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
 @@ -425,6 +425,7 @@ public class NameReferencingFileConverter {
@@ -34,5 +34,5 @@ index 0794aff..2cca728 100644
  
          flag = flag && f(minecraftserver);
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0030-EntityKnockbackEvent.patch
+++ b/patches/server/0030-EntityKnockbackEvent.patch
@@ -1,17 +1,17 @@
-From aca032c59cacd87be7676274000965093f1be532 Mon Sep 17 00:00:00 2001
+From 33140ef3eae3afb7a0dd4b092a5e5e8af5dcb830 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 16 Mar 2014 20:44:46 -0400
 Subject: [PATCH] EntityKnockbackEvent
 
 Control knockback power of entity attacks
 ---
- src/main/java/net/minecraft/server/EnchantmentManager.java | 9 +++++++--
- src/main/java/net/minecraft/server/EntityHuman.java        | 2 +-
- src/main/java/net/minecraft/server/EntityInsentient.java   | 2 +-
+ .../java/net/minecraft/server/EnchantmentManager.java    | 9 +++++++--
+ src/main/java/net/minecraft/server/EntityHuman.java      | 2 +-
+ src/main/java/net/minecraft/server/EntityInsentient.java | 2 +-
  3 files changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EnchantmentManager.java b/src/main/java/net/minecraft/server/EnchantmentManager.java
-index 1d16919..e988f05 100644
+index 1d16919e6..e988f0554 100644
 --- a/src/main/java/net/minecraft/server/EnchantmentManager.java
 +++ b/src/main/java/net/minecraft/server/EnchantmentManager.java
 @@ -181,8 +181,13 @@ public class EnchantmentManager {
@@ -31,7 +31,7 @@ index 1d16919..e988f05 100644
  
      public static int getFireAspectEnchantmentLevel(EntityLiving entityliving) {
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index c385188..35dcc18 100644
+index c385188fe..35dcc18f4 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -997,7 +997,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -44,7 +44,7 @@ index c385188..35dcc18 100644
                      if (this.isSprinting() && flag) {
                          sendSoundEffect(this, this.locX, this.locY, this.locZ, SoundEffects.ENTITY_PLAYER_ATTACK_KNOCKBACK, this.getSoundCategory(), 1.0F, 1.0F);  // Paper - send while respecting visibility
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 47bdfee..0134995 100644
+index 47bdfeec7..013499541 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -1285,7 +1285,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -57,5 +57,5 @@ index 47bdfee..0134995 100644
  
          int i = EnchantmentManager.getFireAspectEnchantmentLevel(this);
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0032-Cancel-Vehicle-Passenger-if-spawn-is-cancelled.patch
+++ b/patches/server/0032-Cancel-Vehicle-Passenger-if-spawn-is-cancelled.patch
@@ -1,15 +1,15 @@
-From 2f729ae6fba0c1da24200edaef7010bf8372f31d Mon Sep 17 00:00:00 2001
+From 42e14609a2c61aa08944b30140ac96fed32f57e6 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 25 Apr 2014 00:38:10 -0400
 Subject: [PATCH] Cancel Vehicle/Passenger if spawn is cancelled
 
 Otherwise lots of chickens
 ---
- .../java/org/bukkit/craftbukkit/event/CraftEventFactory.java   | 10 ++++++++++
+ .../bukkit/craftbukkit/event/CraftEventFactory.java    | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6751277..c1734a1 100644
+index 675127700..c1734a166 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -613,6 +613,16 @@ public class CraftEventFactory {
@@ -30,5 +30,5 @@ index 6751277..c1734a1 100644
      }
  
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0034-Add-Player.spigot-.getFishingHook-API.patch
+++ b/patches/server/0034-Add-Player.spigot-.getFishingHook-API.patch
@@ -1,16 +1,16 @@
-From 8646faa42006a5e4ceb369e6aa44f49a80312ae3 Mon Sep 17 00:00:00 2001
+From b352cec6319fb9162720ba26b4b9e8780ad3a892 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 14 Aug 2014 18:23:33 -0400
 Subject: [PATCH] Add Player.spigot().getFishingHook() API
 
 ---
- src/main/java/net/minecraft/server/EntityFishingHook.java    | 5 +++--
- src/main/java/net/minecraft/server/ItemFishingRod.java       | 3 ++-
- src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java | 8 ++++++++
+ src/main/java/net/minecraft/server/EntityFishingHook.java | 5 +++--
+ src/main/java/net/minecraft/server/ItemFishingRod.java    | 3 ++-
+ .../java/org/bukkit/craftbukkit/entity/CraftPlayer.java   | 8 ++++++++
  3 files changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
-index 2a35170..0720c69 100644
+index 2a351701b..0720c69f1 100644
 --- a/src/main/java/net/minecraft/server/EntityFishingHook.java
 +++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
 @@ -436,8 +436,9 @@ public class EntityFishingHook extends Entity {
@@ -26,7 +26,7 @@ index 2a35170..0720c69 100644
              return 0;
          }
 diff --git a/src/main/java/net/minecraft/server/ItemFishingRod.java b/src/main/java/net/minecraft/server/ItemFishingRod.java
-index 37c4707..af24662 100644
+index 37c4707cf..af24662c6 100644
 --- a/src/main/java/net/minecraft/server/ItemFishingRod.java
 +++ b/src/main/java/net/minecraft/server/ItemFishingRod.java
 @@ -34,9 +34,10 @@ public class ItemFishingRod extends Item {
@@ -42,13 +42,14 @@ index 37c4707..af24662 100644
  
              entityhuman.a(enumhand);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e920545..29deff8 100644
+index e920545df..29deff8ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2000,6 +2000,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1999,6 +1999,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     private final Player.Spigot spigot = new Player.Spigot()
      {
  
-         @Override
++        @Override
 +        public org.bukkit.entity.Fish getFishingHook() {
 +            if (getHandle().hookedFish == null) {
 +                return null;
@@ -56,10 +57,9 @@ index e920545..29deff8 100644
 +            return (org.bukkit.entity.Fish) getHandle().hookedFish.getBukkitEntity();
 +        }
 +
-+        @Override
+         @Override
          public InetSocketAddress getRawAddress()
          {
-             return (InetSocketAddress) getHandle().playerConnection.networkManager.getRawAddress();
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0039-Add-BlockBreakNaturally-Event.patch
+++ b/patches/server/0039-Add-BlockBreakNaturally-Event.patch
@@ -1,17 +1,17 @@
-From c669cb6734329c2ba4896e3347dcf9c1e2885645 Mon Sep 17 00:00:00 2001
+From ca269397205ade11787e184ff78b1d175a208dd1 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 18 Dec 2014 22:48:46 -0500
 Subject: [PATCH] Add BlockBreakNaturally Event
 
 To give reliable control over all blocks dropping to world to restore custom item meta
 ---
- src/main/java/net/minecraft/server/Block.java                    | 2 ++
- src/main/java/net/minecraft/server/EntityItem.java               | 1 +
- .../java/org/bukkit/craftbukkit/event/CraftEventFactory.java     | 9 +++++++++
+ src/main/java/net/minecraft/server/Block.java            | 2 ++
+ src/main/java/net/minecraft/server/EntityItem.java       | 1 +
+ .../org/bukkit/craftbukkit/event/CraftEventFactory.java  | 9 +++++++++
  3 files changed, 12 insertions(+)
 
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index e077359..e712548 100644
+index e077359b0..e71254858 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -504,8 +504,10 @@ public class Block implements IMaterial {
@@ -26,7 +26,7 @@ index e077359..e712548 100644
              }
              // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 862d838..da77950 100644
+index 862d83871..da779504e 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
 @@ -16,6 +16,7 @@ public class EntityItem extends Entity {
@@ -38,7 +38,7 @@ index 862d838..da77950 100644
      private int f;
      private UUID thrower;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c1734a1..06e0fb6 100644
+index c1734a166..06e0fb695 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -332,6 +332,15 @@ public class CraftEventFactory {
@@ -58,5 +58,5 @@ index c1734a1..06e0fb6 100644
                  item.world.addEntity(item);
              }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0044-Ignore-statistics-warnings.patch
+++ b/patches/server/0044-Ignore-statistics-warnings.patch
@@ -1,14 +1,14 @@
-From c580bcc559f7d6779365559630fa5af52da1ba10 Mon Sep 17 00:00:00 2001
+From 01144fc8dd3fad48e58ff67a974532be15bc9b4b Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 30 Apr 2015 22:12:01 -0400
 Subject: [PATCH] Ignore statistics warnings
 
 ---
- src/main/java/net/minecraft/server/ServerStatisticManager.java | 6 +++---
+ .../java/net/minecraft/server/ServerStatisticManager.java   | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/ServerStatisticManager.java b/src/main/java/net/minecraft/server/ServerStatisticManager.java
-index 1e911a8..3917853 100644
+index 1e911a889..391785373 100644
 --- a/src/main/java/net/minecraft/server/ServerStatisticManager.java
 +++ b/src/main/java/net/minecraft/server/ServerStatisticManager.java
 @@ -113,15 +113,15 @@ public class ServerStatisticManager extends StatisticManager {
@@ -31,5 +31,5 @@ index 1e911a8..3917853 100644
                              }
                          }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0046-Don-t-use-black-for-default-on-chat-formatting.patch
+++ b/patches/server/0046-Don-t-use-black-for-default-on-chat-formatting.patch
@@ -1,14 +1,14 @@
-From 6d37a122a0330611cc2ef9746d337cefca340510 Mon Sep 17 00:00:00 2001
+From 7ed9760debdf48ca6004ae8e9123859d58302bd1 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 6 May 2015 00:47:48 -0400
 Subject: [PATCH] Don't use black for default on chat formatting
 
 ---
- src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java | 4 ++--
+ .../java/org/bukkit/craftbukkit/util/CraftChatMessage.java    | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-index e7a7417..7e9e77f 100644
+index e7a741724..7e9e77f7a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
 @@ -161,7 +161,7 @@ public final class CraftChatMessage {
@@ -30,5 +30,5 @@ index e7a7417..7e9e77f 100644
                  out.append(EnumChatFormat.BOLD);
              }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0050-Disable-Repair-Cost.patch
+++ b/patches/server/0050-Disable-Repair-Cost.patch
@@ -1,16 +1,16 @@
-From 04060d0d6c8acc4a8f4b57b5d4989f3d1bc24c21 Mon Sep 17 00:00:00 2001
+From c6881d435adfb344debc14bfcab683ef9a228783 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 19 May 2015 23:47:32 -0400
 Subject: [PATCH] Disable Repair Cost
 
 Handled on Plugin Level on a Per Player basis
 ---
- src/main/java/net/minecraft/server/ItemStack.java                 | 4 ++++
- src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java | 2 +-
+ src/main/java/net/minecraft/server/ItemStack.java             | 4 ++++
+ .../java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java  | 2 +-
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index fc41b85..91493b8 100644
+index fc41b8592..91493b861 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -126,6 +126,7 @@ public final class ItemStack {
@@ -36,7 +36,7 @@ index fc41b85..91493b8 100644
          if (i == 0) {
              this.removeTag("RepairCost");
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 1faadbd..482fa7c 100644
+index 1faadbd10..482fa7c8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -395,7 +395,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -49,5 +49,5 @@ index 1faadbd..482fa7c 100644
          }
  
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0051-Improve-Hopper-Performance.patch
+++ b/patches/server/0051-Improve-Hopper-Performance.patch
@@ -1,18 +1,18 @@
-From 5f6f2d173be9607942ac418b4643eab5e8388852 Mon Sep 17 00:00:00 2001
+From 97008afc60311a8aee3e99a45b1c308b941d2e73 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 29 May 2015 21:58:24 -0400
 Subject: [PATCH] Improve Hopper Performance
 
 Only do an item "suck in" action once per second
 ---
- src/main/java/net/minecraft/server/EntityItem.java   | 15 +++++++++++++++
- .../net/minecraft/server/EntityMinecartHopper.java   | 15 +++++++++++++++
- src/main/java/net/minecraft/server/IHopper.java      |  9 ++++++---
- .../java/net/minecraft/server/TileEntityHopper.java  | 20 +++++++++++++++++++-
+ .../java/net/minecraft/server/EntityItem.java | 15 ++++++++++++++
+ .../server/EntityMinecartHopper.java          | 15 ++++++++++++++
+ .../java/net/minecraft/server/IHopper.java    |  9 ++++++---
+ .../minecraft/server/TileEntityHopper.java    | 20 ++++++++++++++++++-
  4 files changed, 55 insertions(+), 4 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index da77950..f3a4dba 100644
+index da779504e..f3a4dbae5 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
 @@ -139,10 +139,24 @@ public class EntityItem extends Entity {
@@ -49,7 +49,7 @@ index da77950..f3a4dba 100644
      // Spigot end
  
 diff --git a/src/main/java/net/minecraft/server/EntityMinecartHopper.java b/src/main/java/net/minecraft/server/EntityMinecartHopper.java
-index c7eaca7..a9d71e0 100644
+index c7eaca719..a9d71e0ec 100644
 --- a/src/main/java/net/minecraft/server/EntityMinecartHopper.java
 +++ b/src/main/java/net/minecraft/server/EntityMinecartHopper.java
 @@ -7,6 +7,7 @@ public class EntityMinecartHopper extends EntityMinecartContainer implements IHo
@@ -80,7 +80,7 @@ index c7eaca7..a9d71e0 100644
 +    // EMC stop
  }
 diff --git a/src/main/java/net/minecraft/server/IHopper.java b/src/main/java/net/minecraft/server/IHopper.java
-index bafa615..198d5cb 100644
+index bafa615df..198d5cb4b 100644
 --- a/src/main/java/net/minecraft/server/IHopper.java
 +++ b/src/main/java/net/minecraft/server/IHopper.java
 @@ -15,9 +15,12 @@ public interface IHopper extends IInventory {
@@ -100,7 +100,7 @@ index bafa615..198d5cb 100644
 -    double B();
  }
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index 83abde9..a701b4f 100644
+index 83abde9c8..a701b4fc0 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
 @@ -91,6 +91,23 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
@@ -145,5 +145,5 @@ index 83abde9..a701b4f 100644
  
      private static boolean a(IHopper ihopper, IInventory iinventory, int i, EnumDirection enumdirection) {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0052-SendSignEvent.patch
+++ b/patches/server/0052-SendSignEvent.patch
@@ -1,17 +1,17 @@
-From d5d2a1dd256bcd94b862a672b61ec0a20cb25118 Mon Sep 17 00:00:00 2001
+From d6fdf2e8325ca8495b898374e181d3c742dbfea6 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 8 Jun 2015 23:55:20 -0400
 Subject: [PATCH] SendSignEvent
 
 ---
- .../com/empireminecraft/api/SendSignEventImpl.java | 42 ++++++++++++++++++++++
- .../java/net/minecraft/server/TileEntitySign.java  | 13 +++++--
+ .../api/SendSignEventImpl.java                | 42 +++++++++++++++++++
+ .../net/minecraft/server/TileEntitySign.java  | 13 +++++-
  2 files changed, 53 insertions(+), 2 deletions(-)
  create mode 100644 src/main/java/com/empireminecraft/api/SendSignEventImpl.java
 
 diff --git a/src/main/java/com/empireminecraft/api/SendSignEventImpl.java b/src/main/java/com/empireminecraft/api/SendSignEventImpl.java
 new file mode 100644
-index 0000000..9f3cb62
+index 000000000..9f3cb62ff
 --- /dev/null
 +++ b/src/main/java/com/empireminecraft/api/SendSignEventImpl.java
 @@ -0,0 +1,42 @@
@@ -58,7 +58,7 @@ index 0000000..9f3cb62
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/TileEntitySign.java b/src/main/java/net/minecraft/server/TileEntitySign.java
-index 6e9d00e..482a4df 100644
+index 6e9d00e2e..482a4df3c 100644
 --- a/src/main/java/net/minecraft/server/TileEntitySign.java
 +++ b/src/main/java/net/minecraft/server/TileEntitySign.java
 @@ -28,10 +28,15 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
@@ -92,5 +92,5 @@ index 6e9d00e..482a4df 100644
  
      @Override
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0055-EMC-Specific-User-API-s.patch
+++ b/patches/server/0055-EMC-Specific-User-API-s.patch
@@ -1,15 +1,15 @@
-From 5fe2fb23915cc02597e3f27a29fa6e76d49223be Mon Sep 17 00:00:00 2001
+From 7dede2eadbb32c77b5210764493a1bb89a45b4de Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 23 Jun 2015 23:35:30 -0400
 Subject: [PATCH] EMC Specific User API's
 
 For quick access to our server user data object and user id
 ---
- .../org/bukkit/craftbukkit/entity/CraftPlayer.java  | 21 +++++++++++++++++++++
+ .../craftbukkit/entity/CraftPlayer.java       | 21 +++++++++++++++++++
  1 file changed, 21 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 29deff8..55a4898 100644
+index 29deff8ac..55a489822 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -125,6 +125,27 @@ import net.md_5.bungee.api.chat.BaseComponent; // Spigot
@@ -41,5 +41,5 @@ index 29deff8..55a4898 100644
      private long lastPlayed = 0;
      private boolean hasPlayedBefore = false;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0057-Profile-Serialization-Events.patch
+++ b/patches/server/0057-Profile-Serialization-Events.patch
@@ -1,15 +1,15 @@
-From d0c3d7f1f14a88853d209cbcd9d659afc7a8cc92 Mon Sep 17 00:00:00 2001
+From b02979f3ea9ead237d94bfd3aec757b2c5a25c2b Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 21 Jul 2015 23:05:32 -0400
 Subject: [PATCH] Profile Serialization Events
 
 Lets us modify profile data before/after it is serialized/deserialized.
 ---
- .../java/net/minecraft/server/GameProfileSerializer.java     | 12 ++++++++++--
+ .../net/minecraft/server/GameProfileSerializer.java  | 12 ++++++++++--
  1 file changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/GameProfileSerializer.java b/src/main/java/net/minecraft/server/GameProfileSerializer.java
-index d4ad6b0..131726b 100644
+index d4ad6b032..131726b2e 100644
 --- a/src/main/java/net/minecraft/server/GameProfileSerializer.java
 +++ b/src/main/java/net/minecraft/server/GameProfileSerializer.java
 @@ -1,5 +1,6 @@
@@ -59,5 +59,5 @@ index d4ad6b0..131726b 100644
  
      public static NBTTagCompound a(DataFixer datafixer, DataFixTypes datafixtypes, NBTTagCompound nbttagcompound, int i) {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0058-Implement-BatMoveEvent.patch
+++ b/patches/server/0058-Implement-BatMoveEvent.patch
@@ -1,16 +1,16 @@
-From 660ed1d89664c8882e8319dca6c375604a2aed58 Mon Sep 17 00:00:00 2001
+From faa8812e20c19b3016fbb951ca0dbf729c4a57f9 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 16 Nov 2015 23:23:03 -0500
 Subject: [PATCH] Implement BatMoveEvent
 
 Control where the bat goes
 ---
- src/main/java/net/minecraft/server/EntityBat.java        | 15 ++++++++++++++-
- src/main/java/net/minecraft/server/EntityInsentient.java |  2 +-
+ src/main/java/net/minecraft/server/EntityBat.java | 15 ++++++++++++++-
+ .../net/minecraft/server/EntityInsentient.java    |  2 +-
  2 files changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityBat.java b/src/main/java/net/minecraft/server/EntityBat.java
-index 3bc9f0d..8d9ec68 100644
+index 3bc9f0dd7..8d9ec68c3 100644
 --- a/src/main/java/net/minecraft/server/EntityBat.java
 +++ b/src/main/java/net/minecraft/server/EntityBat.java
 @@ -127,7 +127,7 @@ public class EntityBat extends EntityAmbient {
@@ -41,7 +41,7 @@ index 3bc9f0d..8d9ec68 100644
 +    // EMC end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 0134995..2803b6e 100644
+index 013499541..2803b6e86 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -113,7 +113,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -54,5 +54,5 @@ index 0134995..2803b6e 100644
  
              return entityinsentient.getControllerMove();
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0060-Reload-Entity-API.patch
+++ b/patches/server/0060-Reload-Entity-API.patch
@@ -1,15 +1,15 @@
-From 54dcf55f30a91aa38fa8afacdac1ec4c323475fc Mon Sep 17 00:00:00 2001
+From 20c03a96127914ebc1aa843d4b3c8dfbec883fc8 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 13 Dec 2015 01:19:17 -0500
 Subject: [PATCH] Reload Entity API
 
 ---
- src/main/java/net/minecraft/server/WorldServer.java          |  2 +-
- src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java | 10 ++++++++++
+ src/main/java/net/minecraft/server/WorldServer.java    |  2 +-
+ .../org/bukkit/craftbukkit/entity/CraftEntity.java     | 10 ++++++++++
  2 files changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 1319858..9e63f0a 100644
+index bf9f52126..d854609f5 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -52,7 +52,7 @@ public class WorldServer extends World {
@@ -22,7 +22,7 @@ index 1319858..9e63f0a 100644
      public final List<EntityPlayer> players = Lists.newArrayList(); // Paper - private -> public
      boolean tickingEntities;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index f1299c6..d0c5dd4 100644
+index f1299c6ed..d0c5dd4f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1071,4 +1071,14 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -41,5 +41,5 @@ index f1299c6..d0c5dd4 100644
 +    // EMC stop
  }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0061-SnowmanThrowSnowballEvent.patch
+++ b/patches/server/0061-SnowmanThrowSnowballEvent.patch
@@ -1,14 +1,14 @@
-From dac9486f21abcd7634b7be5c34defde8bf6c68aa Mon Sep 17 00:00:00 2001
+From 2ce9c4a383cd2bfb899ee190cbcf87fbec2fa1c6 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 21 Dec 2015 13:33:00 -0500
 Subject: [PATCH] SnowmanThrowSnowballEvent
 
 ---
- .../java/net/minecraft/server/EntitySnowman.java     | 20 ++++++++++++++++++++
+ .../net/minecraft/server/EntitySnowman.java   | 20 +++++++++++++++++++
  1 file changed, 20 insertions(+)
 
 diff --git a/src/main/java/net/minecraft/server/EntitySnowman.java b/src/main/java/net/minecraft/server/EntitySnowman.java
-index fe1381c..fe31157 100644
+index fe1381cc1..fe3115793 100644
 --- a/src/main/java/net/minecraft/server/EntitySnowman.java
 +++ b/src/main/java/net/minecraft/server/EntitySnowman.java
 @@ -10,6 +10,25 @@ public class EntitySnowman extends EntityGolem implements IRangedEntity {
@@ -46,5 +46,5 @@ index fe1381c..fe31157 100644
          this.world.addEntity(entitysnowball);
      }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0062-Improve-Task-Exception-Logging.patch
+++ b/patches/server/0062-Improve-Task-Exception-Logging.patch
@@ -1,14 +1,14 @@
-From 79e7361cbb06e43f5bd2e51bd113f6db3c47ff6d Mon Sep 17 00:00:00 2001
+From 828292816b36b7be37f65d26d2c6cecde955a09e Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 23 Dec 2015 05:28:12 -0500
 Subject: [PATCH] Improve Task Exception Logging
 
 ---
- src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java | 2 +-
+ .../java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java   | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 5db848d..33ffdfe 100644
+index 5db848de1..33ffdfeb8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -457,7 +457,7 @@ public class CraftScheduler implements BukkitScheduler {
@@ -21,5 +21,5 @@ index 5db848d..33ffdfe 100644
                              throwable);
                      task.getOwner().getServer().getPluginManager().callEvent(
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0064-Player-Death-fires-PlayerDropItem-event.patch
+++ b/patches/server/0064-Player-Death-fires-PlayerDropItem-event.patch
@@ -1,15 +1,15 @@
-From dc5416903a2fc74671f6aa8ed6d6fdee440af98a Mon Sep 17 00:00:00 2001
+From 6225a10c608ecf88489478f9f5a69da3b895bdd4 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 17 Jan 2016 03:42:03 -0500
 Subject: [PATCH] Player Death fires PlayerDropItem event
 
 ---
- src/main/java/net/minecraft/server/EntityHuman.java               | 1 +
- src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java | 2 +-
+ src/main/java/net/minecraft/server/EntityHuman.java             | 1 +
+ .../java/org/bukkit/craftbukkit/event/CraftEventFactory.java    | 2 +-
  2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 35dcc18..f1f362b 100644
+index 35dcc18f4..f1f362b36 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -560,6 +560,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -21,7 +21,7 @@ index 35dcc18..f1f362b 100644
          if (itemstack.isEmpty()) {
              return null;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 06e0fb6..4e44c1a 100644
+index 06e0fb695..4e44c1a8f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -801,7 +801,7 @@ public class CraftEventFactory {
@@ -34,5 +34,5 @@ index 06e0fb6..4e44c1a 100644
  
          return event;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0066-Allow-Vehicle-Passenger-Teleporting-for-Bukkit-API.patch
+++ b/patches/server/0066-Allow-Vehicle-Passenger-Teleporting-for-Bukkit-API.patch
@@ -1,18 +1,18 @@
-From bc8c3d3f4344472201770b86f24fa834373079d3 Mon Sep 17 00:00:00 2001
+From 1d29b6ce605b05c057985795b839f2a76f5c5c09 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 10 Apr 2016 22:50:33 -0400
 Subject: [PATCH] Allow Vehicle/Passenger Teleporting for Bukkit API
 
 If Bukkit teleport is called, teleport the whole set of entities together and maintain the chain.
 ---
- src/main/java/net/minecraft/server/Entity.java     | 22 +++++++-
- .../net/minecraft/server/PlayerConnection.java     | 24 ++++++---
- .../org/bukkit/craftbukkit/entity/CraftEntity.java | 59 +++++++++++++++++++++-
- .../org/bukkit/craftbukkit/entity/CraftPlayer.java |  5 +-
+ .../java/net/minecraft/server/Entity.java     | 22 ++++++-
+ .../minecraft/server/PlayerConnection.java    | 24 ++++++--
+ .../craftbukkit/entity/CraftEntity.java       | 59 ++++++++++++++++++-
+ .../craftbukkit/entity/CraftPlayer.java       |  5 +-
  4 files changed, 100 insertions(+), 10 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 295089b..b0f7222 100644
+index 295089bd2..b0f72223a 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -104,7 +104,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -52,7 +52,7 @@ index 295089b..b0f7222 100644
      public float pitch;
      public float lastYaw;
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index e7c49bf..8155e76 100644
+index e7c49bf87..8155e764a 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -88,12 +88,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -94,7 +94,7 @@ index e7c49bf..8155e76 100644
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index d0c5dd4..0040aad 100644
+index d0c5dd4f1..0040aadff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -496,6 +496,58 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -186,7 +186,7 @@ index d0c5dd4..0040aad 100644
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 55a4898..3a62c8f 100644
+index 55a489822..3a62c8f50 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -791,7 +791,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -209,5 +209,5 @@ index 55a4898..3a62c8f 100644
      }
  
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0074-Villager-Treasure-Map-Events-Changes.patch
+++ b/patches/server/0074-Villager-Treasure-Map-Events-Changes.patch
@@ -1,18 +1,18 @@
-From 2d77c424b77e0caa983e5b8717895fc87914b2d3 Mon Sep 17 00:00:00 2001
+From aa8d3c7de6b5200d2d70e582a120ac95d7a40795 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 13 Dec 2016 00:40:10 -0500
 Subject: [PATCH] Villager Treasure Map Events / Changes
 
 ---
- .../com/empireminecraft/api/CraftEAPI_Misc.java    | 35 ++++++++++++++++++++++
- .../java/net/minecraft/server/EntityVillager.java  |  1 -
- src/main/java/net/minecraft/server/ItemStack.java  |  1 +
- .../java/net/minecraft/server/VillagerTrades.java  | 27 +++++++++--------
- src/main/java/net/minecraft/server/World.java      |  2 +-
+ .../empireminecraft/api/CraftEAPI_Misc.java   | 35 +++++++++++++++++++
+ .../net/minecraft/server/EntityVillager.java  |  1 -
+ .../java/net/minecraft/server/ItemStack.java  |  1 +
+ .../net/minecraft/server/VillagerTrades.java  | 27 +++++++-------
+ src/main/java/net/minecraft/server/World.java |  2 +-
  5 files changed, 51 insertions(+), 15 deletions(-)
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java b/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
-index fa8cbd5..2065032 100644
+index fa8cbd5a3..206503283 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
 @@ -23,5 +23,40 @@
@@ -57,7 +57,7 @@ index fa8cbd5..2065032 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index c2ccb85..7bba571 100644
+index c2ccb8589..7bba5714f 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
 @@ -387,7 +387,6 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
@@ -69,7 +69,7 @@ index c2ccb85..7bba571 100644
                  MerchantRecipe merchantrecipe1 = (MerchantRecipe) iterator1.next();
                  double d0 = 0.3D + 0.0625D * (double) j;
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index 91493b8..93cbf0d 100644
+index 91493b861..93cbf0d51 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -669,6 +669,7 @@ public final class ItemStack {
@@ -81,7 +81,7 @@ index 91493b8..93cbf0d 100644
          NBTTagCompound nbttagcompound = this.a("display");
  
 diff --git a/src/main/java/net/minecraft/server/VillagerTrades.java b/src/main/java/net/minecraft/server/VillagerTrades.java
-index 819e0ef..4751b82 100644
+index 819e0efdb..4751b8261 100644
 --- a/src/main/java/net/minecraft/server/VillagerTrades.java
 +++ b/src/main/java/net/minecraft/server/VillagerTrades.java
 @@ -72,17 +72,19 @@ public class VillagerTrades {
@@ -132,7 +132,7 @@ index 819e0ef..4751b82 100644
              } else {
                  return null;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 01a7c30..b80f61e 100644
+index 01a7c30d7..b80f61e50 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1606,7 +1606,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -145,5 +145,5 @@ index 01a7c30..b80f61e 100644
      }
  
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0075-Make-CraftMetaItem-not-crash-on-HideFlags-error.patch
+++ b/patches/server/0075-Make-CraftMetaItem-not-crash-on-HideFlags-error.patch
@@ -1,14 +1,14 @@
-From 6137d3eb341b9c44b7722acb7d44f02e9f62270a Mon Sep 17 00:00:00 2001
+From 6ac112d1a87366e272cdcb390ffc97b822962142 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 29 Dec 2016 23:27:50 -0500
 Subject: [PATCH] Make CraftMetaItem not crash on HideFlags error
 
 ---
- src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java | 7 ++++++-
+ .../org/bukkit/craftbukkit/inventory/CraftMetaItem.java    | 7 ++++++-
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 482fa7c..916e9c8 100644
+index 482fa7c8e..916e9c825 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -233,7 +233,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -26,5 +26,5 @@ index 482fa7c..916e9c8 100644
      }
  
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0077-ShulkerBox-API.patch
+++ b/patches/server/0077-ShulkerBox-API.patch
@@ -1,15 +1,15 @@
-From d4ab0637dd6b0f3398a855f198584dad2788228f Mon Sep 17 00:00:00 2001
+From 7fc919487d9d6c0a718b7f75397cdccea29a2dfc Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 1 Jan 2017 20:36:31 -0500
 Subject: [PATCH] ShulkerBox API
 
 ---
- .../com/empireminecraft/api/CraftEAPI_Misc.java    | 53 ++++++++++++++++++++++
- src/main/java/net/minecraft/server/ItemStack.java  |  1 +
+ .../empireminecraft/api/CraftEAPI_Misc.java   | 53 +++++++++++++++++++
+ .../java/net/minecraft/server/ItemStack.java  |  1 +
  2 files changed, 54 insertions(+)
 
 diff --git a/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java b/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
-index 2065032..f4cbde2 100644
+index 206503283..f4cbde24a 100644
 --- a/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
 +++ b/src/main/java/com/empireminecraft/api/CraftEAPI_Misc.java
 @@ -23,17 +23,24 @@
@@ -89,7 +89,7 @@ index 2065032..f4cbde2 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index 93cbf0d..d789ffd 100644
+index 93cbf0d51..d789ffd92 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -137,6 +137,7 @@ public final class ItemStack {
@@ -101,5 +101,5 @@ index 93cbf0d..d789ffd 100644
          try {
              return new ItemStack(nbttagcompound);
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0078-Convert-Horse-Eggs-with-EMC-Metadata.patch
+++ b/patches/server/0078-Convert-Horse-Eggs-with-EMC-Metadata.patch
@@ -1,4 +1,4 @@
-From 2d497d5a4d0551c9564a1a06c19feef0aa4ffda9 Mon Sep 17 00:00:00 2001
+From 826f03fed3301cbae5737e647176457d2aa38ebc Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 29 Dec 2016 17:37:46 -0500
 Subject: [PATCH] Convert Horse Eggs with EMC Metadata
@@ -7,12 +7,12 @@ We stored the Variant in the lore. This allows us to convert those
 horse eggs so that they have the appropriate icon color without
 spawning and re-eggifying it.
 ---
- .../java/org/bukkit/craftbukkit/CraftServer.java   |   1 +
- .../craftbukkit/inventory/CraftMetaSpawnEgg.java   | 102 +++++++++++++++++++++
+ .../org/bukkit/craftbukkit/CraftServer.java   |   1 +
+ .../inventory/CraftMetaSpawnEgg.java          | 102 ++++++++++++++++++
  2 files changed, 103 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 787f4c7..62655b4 100644
+index 787f4c706..62655b459 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -264,6 +264,7 @@ public final class CraftServer implements Server {
@@ -24,7 +24,7 @@ index 787f4c7..62655b4 100644
          if (!Main.useConsole) {
              getLogger().info("Console input is disabled due to --noconsole command argument");
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-index 082f851..3ee286e 100644
+index 082f85119..3ee286efe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 @@ -83,10 +83,112 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
@@ -141,5 +141,5 @@ index 082f851..3ee286e 100644
      void serializeInternal(Map<String, NBTBase> internalTags) {
          if (entityTag != null && !entityTag.isEmpty()) {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0080-EntityAttackedEntityEvent.patch
+++ b/patches/server/0080-EntityAttackedEntityEvent.patch
@@ -1,4 +1,4 @@
-From 7f561ae0cf4a39bb7ab9f18db011d49aae7ed56c Mon Sep 17 00:00:00 2001
+From f2fbdfc2130e22fccf959ed920139c60061e4299 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 20 Dec 2017 21:42:45 -0500
 Subject: [PATCH] EntityAttackedEntityEvent
@@ -6,11 +6,11 @@ Subject: [PATCH] EntityAttackedEntityEvent
 For when you need to know one Entity has attacked another entity
 and that the damage event was not cancelled.
 ---
- src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java | 7 +++++++
+ .../org/bukkit/craftbukkit/event/CraftEventFactory.java    | 7 +++++++
  1 file changed, 7 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4e44c1a..28f9d2c 100644
+index 4e44c1a8f..28f9d2c38 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -985,7 +985,14 @@ public class CraftEventFactory {
@@ -29,5 +29,5 @@ index 4e44c1a..28f9d2c 100644
  
          return event;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0082-Human-getAttackPct.patch
+++ b/patches/server/0082-Human-getAttackPct.patch
@@ -1,15 +1,15 @@
-From 85ac8b8ef5f46f3625285288276188a45c9b0467 Mon Sep 17 00:00:00 2001
+From 782ba97a7f27e3edb0bec125143bc74bee99fb90 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 17 Jun 2018 02:09:37 -0400
 Subject: [PATCH] Human#getAttackPct
 
 ---
- src/main/java/net/minecraft/server/EntityHuman.java               | 2 ++
- src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java | 2 ++
+ src/main/java/net/minecraft/server/EntityHuman.java             | 2 ++
+ .../java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java    | 2 ++
  2 files changed, 4 insertions(+)
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index b6ddd09..ed8bdca 100644
+index b6ddd0990..ed8bdca77 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -80,6 +80,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -29,7 +29,7 @@ index b6ddd09..ed8bdca 100644
                  f *= 0.2F + f2 * f2 * 0.8F;
                  f1 *= f2;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 81cf5f4..b9ef0bf 100644
+index 81cf5f47a..b9ef0bf84 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -85,6 +85,8 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -42,5 +42,5 @@ index 81cf5f4..b9ef0bf 100644
          super(server, entity);
          mode = server.getDefaultGameMode();
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0085-EntityRandomStrollEvent.patch
+++ b/patches/server/0085-EntityRandomStrollEvent.patch
@@ -1,14 +1,14 @@
-From f8d0e6a289eda4c223c5c7574dfce15b0845e63e Mon Sep 17 00:00:00 2001
+From 42e2693442c833231f5a5e440b8d551783208516 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 25 Jun 2018 22:30:08 -0400
 Subject: [PATCH] EntityRandomStrollEvent
 
 ---
- .../server/PathfinderGoalRandomStroll.java          | 21 +++++++++++++++------
+ .../server/PathfinderGoalRandomStroll.java    | 21 +++++++++++++------
  1 file changed, 15 insertions(+), 6 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalRandomStroll.java b/src/main/java/net/minecraft/server/PathfinderGoalRandomStroll.java
-index e74b169..ab5b51c 100644
+index e74b16948..ab5b51c74 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalRandomStroll.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalRandomStroll.java
 @@ -5,11 +5,11 @@ import javax.annotation.Nullable;
@@ -47,5 +47,5 @@ index e74b169..ab5b51c 100644
  
      public void h() {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0086-EntityPrepForRangedAttack.patch
+++ b/patches/server/0086-EntityPrepForRangedAttack.patch
@@ -1,16 +1,16 @@
-From 93ecf47a12ec656720f6524d5fd2fabbae6bd817 Mon Sep 17 00:00:00 2001
+From 6dd2112da6971c9e4f9087e8a9e5ac3bf5cae930 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 25 Jun 2018 22:55:42 -0400
 Subject: [PATCH] EntityPrepForRangedAttack
 
 ---
- .../net/minecraft/server/NavigationAbstract.java   |  1 +
- .../server/PathfinderGoalArrowAttack.java          | 27 ++++++++++++++--------
- .../minecraft/server/PathfinderGoalBowShoot.java   | 22 ++++++++++++------
+ .../minecraft/server/NavigationAbstract.java  |  1 +
+ .../server/PathfinderGoalArrowAttack.java     | 27 ++++++++++++-------
+ .../server/PathfinderGoalBowShoot.java        | 22 ++++++++++-----
  3 files changed, 34 insertions(+), 16 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/NavigationAbstract.java b/src/main/java/net/minecraft/server/NavigationAbstract.java
-index 66e1010..9c7d620 100644
+index 66e10108d..9c7d62001 100644
 --- a/src/main/java/net/minecraft/server/NavigationAbstract.java
 +++ b/src/main/java/net/minecraft/server/NavigationAbstract.java
 @@ -150,6 +150,7 @@ public abstract class NavigationAbstract {
@@ -22,7 +22,7 @@ index 66e1010..9c7d620 100644
          PathEntity pathentity = this.a(entity, 1);
  
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java b/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java
-index 8cbf77e..03b1d54 100644
+index 8cbf77eeb..03b1d5434 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalArrowAttack.java
 @@ -4,16 +4,16 @@ import java.util.EnumSet;
@@ -72,7 +72,7 @@ index 8cbf77e..03b1d54 100644
  
          this.a.getControllerLook().a(this.c, 30.0F, 30.0F);
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java b/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java
-index fd544c2..f675740 100644
+index fd544c29a..f6757408e 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalBowShoot.java
 @@ -4,12 +4,12 @@ import java.util.EnumSet;
@@ -116,5 +116,5 @@ index fd544c2..f675740 100644
              }
  
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0091-Current-progress-on-old-horse-datafixer.patch
+++ b/patches/server/0091-Current-progress-on-old-horse-datafixer.patch
@@ -1,18 +1,18 @@
-From 13c7597641068160df8d8e994c2610c34a09e536 Mon Sep 17 00:00:00 2001
+From a9deac3ab405e496fcfd7b43166000823975a073 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 6 Aug 2018 01:42:52 -0400
 Subject: [PATCH] Current progress on old horse datafixer
 
 ---
- .../minecraft/server/DataConverterRegistry.java    |   1 +
- .../minecraft/server/EmpireHorseEggDataFixer.java  | 123 +++++++++++++++++++++
- .../java/org/bukkit/craftbukkit/CraftServer.java   |   1 -
- .../craftbukkit/inventory/CraftMetaSpawnEgg.java   |  61 ----------
+ .../server/DataConverterRegistry.java         |   1 +
+ .../server/EmpireHorseEggDataFixer.java       | 123 ++++++++++++++++++
+ .../org/bukkit/craftbukkit/CraftServer.java   |   1 -
+ .../inventory/CraftMetaSpawnEgg.java          |  61 ---------
  4 files changed, 124 insertions(+), 62 deletions(-)
  create mode 100644 src/main/java/net/minecraft/server/EmpireHorseEggDataFixer.java
 
 diff --git a/src/main/java/net/minecraft/server/DataConverterRegistry.java b/src/main/java/net/minecraft/server/DataConverterRegistry.java
-index 6458576..1408d95 100644
+index 645857604..1408d95a1 100644
 --- a/src/main/java/net/minecraft/server/DataConverterRegistry.java
 +++ b/src/main/java/net/minecraft/server/DataConverterRegistry.java
 @@ -39,6 +39,7 @@ public class DataConverterRegistry {
@@ -25,7 +25,7 @@ index 6458576..1408d95 100644
          Schema schema5 = datafixerbuilder.addSchema(106, DataConverterSchemaV106::new);
 diff --git a/src/main/java/net/minecraft/server/EmpireHorseEggDataFixer.java b/src/main/java/net/minecraft/server/EmpireHorseEggDataFixer.java
 new file mode 100644
-index 0000000..0f95ad5
+index 000000000..0f95ad5a4
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/EmpireHorseEggDataFixer.java
 @@ -0,0 +1,123 @@
@@ -153,7 +153,7 @@ index 0000000..0f95ad5
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 62655b4..787f4c7 100644
+index 62655b459..787f4c706 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -264,7 +264,6 @@ public final class CraftServer implements Server {
@@ -165,7 +165,7 @@ index 62655b4..787f4c7 100644
          if (!Main.useConsole) {
              getLogger().info("Console input is disabled due to --noconsole command argument");
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-index 3ee286e..f92f7e8 100644
+index 3ee286efe..f92f7e8a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 @@ -89,67 +89,6 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
@@ -237,5 +237,5 @@ index 3ee286e..f92f7e8 100644
          if (spawnedType != EntityType.HORSE) {
              return;
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0092-Contextual-Identifer-API.patch
+++ b/patches/server/0092-Contextual-Identifer-API.patch
@@ -1,4 +1,4 @@
-From 60b21af40a93b8ce2393ea6002cff119bb05f95c Mon Sep 17 00:00:00 2001
+From 06c65b45505e069dd457f5f27299a29a23339688 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 17 May 2016 19:46:42 -0400
 Subject: [PATCH] Contextual Identifer API
@@ -13,11 +13,11 @@ But we may want to store counting data by chunk, but also by Residence, and cach
 
 Objects represented by an Identifier, should be able to use them as their equal/hashcodes.
 ---
- .../java/org/bukkit/craftbukkit/CraftChunk.java    | 43 ++++++++++++++++++++++
+ .../org/bukkit/craftbukkit/CraftChunk.java    | 43 +++++++++++++++++++
  1 file changed, 43 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 0bd7420..d9f047f 100644
+index 0bd7420b1..d9f047f2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -46,6 +46,7 @@ public class CraftChunk implements Chunk {
@@ -76,5 +76,5 @@ index 0bd7420..d9f047f 100644
 +    // EMC stop
  }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0093-SpawnEggMeta-setSpawnedEntity-API.patch
+++ b/patches/server/0093-SpawnEggMeta-setSpawnedEntity-API.patch
@@ -1,4 +1,4 @@
-From dc1b2fc117712a6cc7409d852efe6b46c908f17c Mon Sep 17 00:00:00 2001
+From 748bbaf53714cd26cea5d2f68035fb2b1cc805ec Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 18 Aug 2018 22:03:33 -0400
 Subject: [PATCH] SpawnEggMeta#setSpawnedEntity API
@@ -7,11 +7,11 @@ lets you copy an entities data into a spawn egg.
 Partial data is supported through a predicate, letting MC
 follow normal spawn behavior in the summon phase.
 ---
- .../craftbukkit/inventory/CraftMetaSpawnEgg.java      | 19 +++++++++++++++++++
+ .../inventory/CraftMetaSpawnEgg.java          | 19 +++++++++++++++++++
  1 file changed, 19 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-index f92f7e8..1279240 100644
+index f92f7e8a0..1279240d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 @@ -2,6 +2,7 @@ package org.bukkit.craftbukkit.inventory;
@@ -48,5 +48,5 @@ index f92f7e8..1279240 100644
      public EntityType getSpawnedType() {
          throw new UnsupportedOperationException("Must check item type to get spawned type");
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0094-Legacy-Data-Converter.patch
+++ b/patches/server/0094-Legacy-Data-Converter.patch
@@ -1,16 +1,16 @@
-From 2394c9bcae9242750eb5b4ec2e58704012e723c6 Mon Sep 17 00:00:00 2001
+From 0c06d2c498c46149de95e5ec3ef7dea5e7df8ef5 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 21 Mar 2019 23:31:44 -0400
 Subject: [PATCH] Legacy Data Converter
 
 ---
- .../minecraft/server/DataConverterRegistry.java    |    2 +-
- .../java/net/minecraft/server/DataConverters.java  | 2601 ++++++++++++++++++++
+ .../server/DataConverterRegistry.java         |    2 +-
+ .../net/minecraft/server/DataConverters.java  | 2601 +++++++++++++++++
  2 files changed, 2602 insertions(+), 1 deletion(-)
  create mode 100644 src/main/java/net/minecraft/server/DataConverters.java
 
 diff --git a/src/main/java/net/minecraft/server/DataConverterRegistry.java b/src/main/java/net/minecraft/server/DataConverterRegistry.java
-index 1408d95..a6f703b 100644
+index 1408d95a1..a6f703b6c 100644
 --- a/src/main/java/net/minecraft/server/DataConverterRegistry.java
 +++ b/src/main/java/net/minecraft/server/DataConverterRegistry.java
 @@ -16,7 +16,7 @@ public class DataConverterRegistry {
@@ -24,7 +24,7 @@ index 1408d95..a6f703b 100644
          return datafixerbuilder.build(SystemUtils.e());
 diff --git a/src/main/java/net/minecraft/server/DataConverters.java b/src/main/java/net/minecraft/server/DataConverters.java
 new file mode 100644
-index 0000000..9da16f0
+index 000000000..9da16f0d7
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/DataConverters.java
 @@ -0,0 +1,2601 @@
@@ -2630,5 +2630,5 @@ index 0000000..9da16f0
 +    }
 +}
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0095-Convert-Item-Stacks.patch
+++ b/patches/server/0095-Convert-Item-Stacks.patch
@@ -1,17 +1,17 @@
-From 66a6b28f9b872a018646c040b785ffc0bd3c3781 Mon Sep 17 00:00:00 2001
+From 703ebe427dee811565e2fd51e05b20a8cd34cf99 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 30 Mar 2019 00:45:12 -0400
 Subject: [PATCH] Convert Item Stacks
 
 ---
- src/main/java/net/minecraft/server/ItemStack.java    | 15 +++++++++++++--
- .../craftbukkit/inventory/CraftItemFactory.java      | 18 +++++++++++++++++-
- .../bukkit/craftbukkit/inventory/CraftItemStack.java | 20 ++++++++++++++++----
- .../bukkit/craftbukkit/inventory/CraftMetaItem.java  | 14 ++++++++++----
+ .../java/net/minecraft/server/ItemStack.java  | 15 ++++++++++++--
+ .../inventory/CraftItemFactory.java           | 18 ++++++++++++++++-
+ .../craftbukkit/inventory/CraftItemStack.java | 20 +++++++++++++++----
+ .../craftbukkit/inventory/CraftMetaItem.java  | 14 +++++++++----
  4 files changed, 56 insertions(+), 11 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index d789ffd..4bab114 100644
+index d789ffd92..4bab11423 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -95,12 +95,23 @@ public final class ItemStack {
@@ -41,7 +41,7 @@ index d789ffd..4bab114 100644
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 80f71a7..4a61d0b 100644
+index 80f71a77b..4a61d0b75 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 @@ -331,9 +331,25 @@ public final class CraftItemFactory implements ItemFactory {
@@ -72,7 +72,7 @@ index 80f71a7..4a61d0b 100644
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index b8775de..0cee002 100644
+index b8775dee9..0cee00231 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -39,7 +39,11 @@ public final class CraftItemStack extends ItemStack {
@@ -124,7 +124,7 @@ index b8775de..0cee002 100644
          return true;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 916e9c8..484c652 100644
+index 916e9c825..484c6522b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -302,6 +302,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -185,5 +185,5 @@ index 916e9c8..484c652 100644
  
          if (hasLore()) {
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0096-ConduitNewTargetEvent-and-remove-target-for-cancelle.patch
+++ b/patches/server/0096-ConduitNewTargetEvent-and-remove-target-for-cancelle.patch
@@ -1,15 +1,15 @@
-From a0a88d5014215ed900feb76eb30ae8dcda6d4955 Mon Sep 17 00:00:00 2001
+From bfcb977e9e6e3e7128d8ca4432825050ee7d5a31 Mon Sep 17 00:00:00 2001
 From: chickeneer <emcchickeneer@gmail.com>
 Date: Sun, 14 Jul 2019 13:50:53 -0500
 Subject: [PATCH] ConduitNewTargetEvent and remove target for cancelled damage
  events
 
 ---
- src/main/java/net/minecraft/server/TileEntityConduit.java | 11 +++++++++--
+ .../java/net/minecraft/server/TileEntityConduit.java  | 11 +++++++++--
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityConduit.java b/src/main/java/net/minecraft/server/TileEntityConduit.java
-index d5011ec..4571b46 100644
+index d5011ec9b..4571b4604 100644
 --- a/src/main/java/net/minecraft/server/TileEntityConduit.java
 +++ b/src/main/java/net/minecraft/server/TileEntityConduit.java
 @@ -182,7 +182,14 @@ public class TileEntityConduit extends TileEntity implements ITickable {
@@ -38,5 +38,5 @@ index d5011ec..4571b46 100644
              // CraftBukkit end
          }
 -- 
-2.7.4
+2.22.0
 

--- a/patches/server/0097-Fix-Bukkit.createInventory-with-type-LECTERN.patch
+++ b/patches/server/0097-Fix-Bukkit.createInventory-with-type-LECTERN.patch
@@ -1,0 +1,140 @@
+From 06225ca08d11ca43f12bbc6f7ab20bba2ba9330d Mon Sep 17 00:00:00 2001
+From: willies952002 <admin@domnian.com>
+Date: Fri, 16 Aug 2019 22:18:35 -0400
+Subject: [PATCH] Fix Bukkit.createInventory() with type LECTERN
+
+This fixes an issue with Bukkit which makes it possible to open a Lectern interface, but not be able to interact with it (e.g.: change pages). The following changes had to be made:
+
+nms.TileEntityLectern:
+- Add `virtual` flag, this is used to stop calls that would attempt to update a block which we do not have, as well as used in the following change.
+
+nms.TileEntityLectern$LecternInventory
+- in `a(EntityHuman)`, add `(TileEntityLectern.this.virtual && TileEntityLectern.this.hasBook()) ||` to short-circuit the "can use" logic
+- Add `getLectern()` method for use in the following change.
+
+obc.e.CraftHumanEntity#openInventory(Inventory):
+- Check if the wrapped inventory is a TileEntityLectern.LecternInventory, and get the Lectern from that
+
+obc.i.u.CraftTileInventoryConverter$Lectern:
+- Mark the created lectern as "virtual"
+- Override `getInventory(IInventory)` to return a CraftInventoryLectern.
+
+This patch is licensed under the MIT License.
+License: https://opensource.org/licenses/MIT
+---
+ .../net/minecraft/server/TileEntityLectern.java    | 14 +++++++++++---
+ .../craftbukkit/entity/CraftHumanEntity.java       |  5 +++++
+ .../util/CraftTileInventoryConverter.java          | 13 ++++++++++++-
+ 3 files changed, 28 insertions(+), 4 deletions(-)
+
+diff --git a/src/main/java/net/minecraft/server/TileEntityLectern.java b/src/main/java/net/minecraft/server/TileEntityLectern.java
+index 221de42e5..2edfd3619 100644
+--- a/src/main/java/net/minecraft/server/TileEntityLectern.java
++++ b/src/main/java/net/minecraft/server/TileEntityLectern.java
+@@ -18,6 +18,11 @@ public class TileEntityLectern extends TileEntity implements Clearable, ITileInv
+     // CraftBukkit start - add fields and methods
+     public final IInventory inventory = new LecternInventory();
+     public class LecternInventory implements IInventory {
++        // EMC start
++        public TileEntityLectern getLectern() {
++            return TileEntityLectern.this;
++        }
++        // EMC end
+ 
+         public List<HumanEntity> transaction = new ArrayList<>();
+         private int maxStack = 1;
+@@ -75,7 +80,7 @@ public class TileEntityLectern extends TileEntity implements Clearable, ITileInv
+ 
+         @Override
+         public ItemStack splitStack(int i, int j) {
+-            if (i == 0) {
++            if (i == 0 && !TileEntityLectern.this.virtual) { // EMC
+                 ItemStack itemstack = TileEntityLectern.this.book.cloneAndSubtract(j);
+ 
+                 if (TileEntityLectern.this.book.isEmpty()) {
+@@ -90,7 +95,7 @@ public class TileEntityLectern extends TileEntity implements Clearable, ITileInv
+ 
+         @Override
+         public ItemStack splitWithoutUpdate(int i) {
+-            if (i == 0) {
++            if (i == 0 && !TileEntityLectern.this.virtual) { // EMC
+                 ItemStack itemstack = TileEntityLectern.this.book;
+ 
+                 TileEntityLectern.this.book = ItemStack.a;
+@@ -125,7 +130,7 @@ public class TileEntityLectern extends TileEntity implements Clearable, ITileInv
+ 
+         @Override
+         public boolean a(EntityHuman entityhuman) {
+-            return TileEntityLectern.this.world.getTileEntity(TileEntityLectern.this.position) != TileEntityLectern.this ? false : (entityhuman.e((double) TileEntityLectern.this.position.getX() + 0.5D, (double) TileEntityLectern.this.position.getY() + 0.5D, (double) TileEntityLectern.this.position.getZ() + 0.5D) > 64.0D ? false : TileEntityLectern.this.hasBook());
++            return (TileEntityLectern.this.virtual && TileEntityLectern.this.hasBook()) || TileEntityLectern.this.world.getTileEntity(TileEntityLectern.this.position) != TileEntityLectern.this ? false : (entityhuman.e((double) TileEntityLectern.this.position.getX() + 0.5D, (double) TileEntityLectern.this.position.getY() + 0.5D, (double) TileEntityLectern.this.position.getZ() + 0.5D) > 64.0D ? false : TileEntityLectern.this.hasBook());
+         }
+ 
+         @Override
+@@ -158,6 +163,7 @@ public class TileEntityLectern extends TileEntity implements Clearable, ITileInv
+     private ItemStack book;
+     private int page;
+     private int maxPage;
++    public boolean virtual = false; // EMC
+ 
+     public TileEntityLectern() {
+         super(TileEntityTypes.LECTERN);
+@@ -179,6 +185,7 @@ public class TileEntityLectern extends TileEntity implements Clearable, ITileInv
+     }
+ 
+     private void t() {
++        if (this.virtual) return; // EMC
+         this.page = 0;
+         this.maxPage = 0;
+         BlockLectern.setHasBook(this.getWorld(), this.getPosition(), this.getBlock(), false);
+@@ -196,6 +203,7 @@ public class TileEntityLectern extends TileEntity implements Clearable, ITileInv
+ 
+         if (j != this.page) {
+             this.page = j;
++            if (this.virtual) return; // EMC
+             this.update();
+             BlockLectern.a(this.getWorld(), this.getPosition(), this.getBlock());
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index b9ef0bf84..7dba29559 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -331,6 +331,11 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+             if (craft.getInventory() instanceof ITileInventory) {
+                 iinventory = (ITileInventory) craft.getInventory();
+             }
++            // EMC start
++            if (craft.getInventory() instanceof TileEntityLectern.LecternInventory) {
++                iinventory = ((TileEntityLectern.LecternInventory)craft.getInventory()).getLectern();
++            }
++            // EMC end
+         }
+ 
+         if (iinventory instanceof ITileInventory) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
+index f6fa0650f..3011f8cce 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
+@@ -125,8 +125,19 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
+ 
+         @Override
+         public IInventory getTileEntity() {
+-            return new TileEntityLectern().inventory;
++            // EMC start
++            TileEntityLectern lectern = new TileEntityLectern();
++            lectern.virtual = true;
++            return lectern.inventory;
++            // EMC end
+         }
++
++        // EMC start
++        @Override
++        public Inventory getInventory(IInventory tileEntity) {
++            return new org.bukkit.craftbukkit.inventory.CraftInventoryLectern(tileEntity);
++        }
++        // EMC end
+     }
+ 
+     public static class Smoker extends CraftTileInventoryConverter {
+-- 
+2.22.0
+


### PR DESCRIPTION
This fixes an issue with Bukkit which makes it possible to open a
Lectern interface, but not be able to interact with it (e.g.: change pages).

The patch is licensed under the [MIT License](https://opensource.org/licenses/MIT).