### PR TITLE
Fix PlayerUseItem Event

### DIFF
--- a/patches/server/0005-PlayerUseItem-Event.patch
+++ b/patches/server/0005-PlayerUseItem-Event.patch
@@ -10,7 +10,7 @@ This lets us control when an item is consumed and change the item.
  2 files changed, 76 insertions(+), 14 deletions(-)
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index b5c595a4b5d74366f4cdc927673ac60923e46e90..bd5c96d335ce02c3584177b8c9cc43fbb5180132 100644
+index 1a61bc7c8a532d11981e47cadfd57e92894bf4dd..26339d571004d5b77f09a107cebf4be947256a00 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -2057,7 +2057,7 @@ public abstract class EntityLiving extends Entity {
@@ -23,7 +23,7 @@ index b5c595a4b5d74366f4cdc927673ac60923e46e90..bd5c96d335ce02c3584177b8c9cc43fb
              this.setSlot(EnumItemSlot.MAINHAND, itemstack);
          } else {
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 6d192b27440ddfd34555005dafefbce6bbb67236..c143a28126b77ca106c6b8b32d11a894774c09eb 100644
+index 6d192b27440ddfd34555005dafefbce6bbb67236..085220ec5eb1271c5b53e92e1904c16d4e85c81e 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
 @@ -402,6 +402,15 @@ public class PlayerInteractManager {
@@ -137,10 +137,10 @@ index 6d192b27440ddfd34555005dafefbce6bbb67236..c143a28126b77ca106c6b8b32d11a894
 +                }
 +                //replace  entityhuman.b(enumhand) with itemstack
 +                ItemActionContext itemactioncontext = new ItemActionContext(entityplayer, enumhand, movingobjectpositionblock);
-+                EnumInteractionResult enuminteractionresult1 = itemstack.placeItem(itemactioncontext, enumhand);
  
 -                    enuminteractionresult1 = itemstack.placeItem(itemactioncontext, enumhand);
 +                int i = itemstack.getCount();
++                EnumInteractionResult enuminteractionresult1 = itemstack.placeItem(itemactioncontext, enumhand);
 +                if (eventPlace.getTempItem() != null) {
 +                    entityplayer.setHand(enumhand, itemstack = orig);
 +                }


### PR DESCRIPTION
This fixes an issue where items would be consumed regardless of gamemode and event outcome

As usual, under MIT license