### PR TITLE
Fix names in script

### DIFF
--- a/ecraft
+++ b/ecraft
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# save name of current file
+self_name="${0##*/}"
+
 # get base dir regardless of execution location
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -87,10 +90,10 @@ case "$1" in
 		cd "$basedir"
 	;;
 	"a" | "api")
-		cd "$basedir/EmpireCraft-API"
+		cd "$basedir/${FORK_NAME}-API"
 	;;
 	"s" | "server")
-		cd "$basedir/EmpireCraft-Server"
+		cd "$basedir/${FORK_NAME}-Server"
 	;;
 	"setup")
 		if [[ -f ~/.bashrc ]] ; then
@@ -100,11 +103,11 @@ case "$1" in
 			fi
 			(grep "alias $NAME=" ~/.bashrc > /dev/null) && (sed -i "s|alias $NAME=.*|alias $NAME='. $SOURCE'|g" ~/.bashrc) || (echo "alias $NAME='. $SOURCE'" >> ~/.bashrc)
 			alias "$NAME=. $SOURCE"
-			echo "You can now just type '$NAME' at any time to access the paper tool."
+			echo "You can now just type '$NAME' at any time to access the $self_name tool."
 		fi
 	;;
 	*)
-		echo "EmpireCraft build tool command. This provides a variety of commands to build and manage the PaperMC build"
+		echo "${FORK_NAME} build tool command. This provides a variety of commands to build and manage the ${FORK_NAME} build"
 		echo "environment. For all of the functionality of this command to be available, you must first run the"
 		echo "'setup' command. View below for details. For essential building and patching, you do not need to do the setup."
 		echo ""
@@ -112,23 +115,23 @@ case "$1" in
 		echo "  * rb, rebuild  | Rebuild patches, can be called from anywhere."
 		echo "  * p, patch     | Apply all patches to top of Paper without building it. Can be run from anywhere."
 		echo "  * up, upstream | Build Paper upstream, pass arg up to update paper. Can be run from anywhere."
-		echo "  * b, build    | Build API and Server but no deploy. Can be ran anywhere."
+		echo "  * b, build     | Build API and Server but no deploy. Can be ran anywhere."
 		echo "  * d, deploy    | Build and Deploy API jar and build Server. Can be ran anywhere."
 		echo ""
 		echo " These commands require the setup command before use:"
 		echo "  * r, root      | Change directory to the root of the project."
-		echo "  * a. api       | Move to the Paper-API directory."
-		echo "  * s, server    | Move to the Paper-Server directory."
+		echo "  * a. api       | Move to the ${FORK_NAME}-API directory."
+		echo "  * s, server    | Move to the ${FORK_NAME}-Server directory."
 		echo "  * e, edit      | Use to edit a specific patch, give it the argument \"server\" or \"api\""
 		echo "                 | respectively to edit the correct project. Use the argument \"continue\" after"
 		echo "                 | the changes have been made to finish and rebuild patches. Can be called from anywhere."
 		echo ""
 		echo "  * setup        | Add an alias to .bashrc to allow full functionality of this script. Run as:"
-		echo "                 |     . ./paper setup"
-		echo "                 | After you run this command you'll be able to just run 'paper' from anywhere."
-		echo "                 | The default name for the resulting alias is 'paper', you can give an argument to override"
+		echo "                 |     . ./$self_name setup"
+		echo "                 | After you run this command you'll be able to just run '$self_name' from anywhere."
+		echo "                 | The default name for the resulting alias is '$self_name', you can give an argument to override"
 		echo "                 | this default, such as:"
-		echo "                 |     . ./paper setup example"
+		echo "                 |     . ./$self_name setup example"
 		echo "                 | Which will allow you to run 'example' instead."
 	;;
 esac


### PR DESCRIPTION
Before this change, the ecraft script still referenced the original PaperMC script name, and specific EmpireCraft fork names in the api/server arguments.

Now, instead of having commands reference `./paper`, it will reference the actual name of the script itself regardless of what it is.